### PR TITLE
Fix optional property inference in shape definitions

### DIFF
--- a/guardis/src/guard.test.ts
+++ b/guardis/src/guard.test.ts
@@ -4955,13 +4955,13 @@ Deno.test("createTypeGuard shape", async (t) => {
   });
 
   await t.step("type inference with guard modes", () => {
-    // .optional field infers T | undefined
+    // .optional field infers optional property
     const isForm = createTypeGuard({
       required: isString,
       optional: isString.optional,
     });
     type Form = typeof isForm._TYPE;
-    assertType<Equals<Form, { required: string; optional: string | undefined }>>();
+    assertType<Equals<Form, { required: string; optional?: string | undefined }>>();
 
     // .or() field infers union
     const isRecord = createTypeGuard({
@@ -5214,6 +5214,44 @@ Deno.test("createTypeGuard shape with string literal constants", async (t) => {
 
     isDeleted.strict({ deletedAt: null, name: "item" });
     assertThrows(() => isDeleted.strict({ deletedAt: "2024-01-01", name: "item" }));
+  });
+});
+
+Deno.test("shape optional property inference", async (t) => {
+  await t.step("optional shape field infers optional property", () => {
+    const isUser = createTypeGuard({ name: isString, email: isString.optional });
+    type User = typeof isUser._TYPE;
+    assertType<Equals<User, { name: string; email?: string | undefined }>>();
+  });
+
+  await t.step("isUndefined shape field infers required property", () => {
+    const isRecord = createTypeGuard({ name: isString, deleted: isUndefined });
+    type Record_ = typeof isRecord._TYPE;
+    assertType<Equals<Record_, { name: string; deleted: undefined }>>();
+  });
+
+  await t.step("mixed required and optional fields", () => {
+    const isProfile = createTypeGuard({
+      name: isString,
+      age: isNumber,
+      bio: isString.optional,
+      avatar: isString.optional,
+    });
+    type Profile = typeof isProfile._TYPE;
+    assertType<Equals<Profile, {
+      name: string;
+      age: number;
+      bio?: string | undefined;
+      avatar?: string | undefined;
+    }>>();
+  });
+
+  await t.step("runtime accepts missing optional properties", () => {
+    const isUser = createTypeGuard({ name: isString, email: isString.optional });
+    assert(isUser({ name: "Alice" }));
+    assert(isUser({ name: "Alice", email: undefined }));
+    assert(isUser({ name: "Alice", email: "alice@test.com" }));
+    assertFalse(isUser({ name: "Alice", email: 123 }));
   });
 });
 

--- a/guardis/src/guard.ts
+++ b/guardis/src/guard.ts
@@ -26,7 +26,7 @@ import type {
   TypeGuardShape,
 } from "./types.ts";
 import { createContext, createStrictContext } from "./context.ts";
-import { type GuardMeta, type GuardWithContext, hasContext, hasName } from "./introspect.ts";
+import { hasContext, hasName } from "./introspect.ts";
 import {
   doesNotHaveProperty,
   exact,
@@ -118,7 +118,7 @@ function validateField(
 
   // Primitive constant — use exact equality check
   if (guard === null || (typeof guard !== "object" && typeof guard !== "function")) {
-    const exactGuard = isExactly(guard) as unknown as GuardWithContext<unknown>;
+    const exactGuard = isExactly(guard);
     const guardCtx = childCtx ?? createContext([key]);
     const r = exactGuard._.context(obj[key], guardCtx);
 
@@ -151,7 +151,7 @@ function validateField(
   if (hasContext(guard as Predicate<unknown>)) {
     const guardCtx = childCtx ?? createContext([key]);
 
-    const r = (guard as unknown as GuardWithContext<unknown>)._.context(obj[key], guardCtx);
+    const r = (guard as unknown as TypeGuard<unknown>)._.context(obj[key], guardCtx);
     if ("value" in r) {
       result[key] = r.value;
     } else if (childCtx) {
@@ -312,7 +312,13 @@ const createOptionalTypeGuard = <T>(
   const optionalContext = (value: unknown, ctx?: Context) =>
     isUndefined(value) ? { value } : context(value, ctx ?? createContext());
 
-  optional._ = { name, parser: optionalParser, context: optionalContext };
+  optional._ = {
+    name,
+    parser: optionalParser,
+    context: optionalContext,
+    optional: true as const,
+  };
+
   optional.strict = createStrictTypeGuard(optionalParser, name);
   optional.assert = optional.strict;
   optional.validate = (value: unknown) => optionalContext(value, createContext());
@@ -355,9 +361,6 @@ const createNotEmptyTypeGuard = <T>(guard: Predicate<T>) => {
 
   return notEmpty as CanBeEmpty<T> extends false ? never : typeof notEmpty;
 };
-
-/** Internal type guard with access to metadata */
-type _TypeGuard<T> = TypeGuard<T> & GuardMeta<T>;
 
 /**
  * Creates a type guard from a parser function.
@@ -1020,7 +1023,7 @@ isTuple.or = <N extends number, T2>(
   guard: TypeGuard<T2>,
 ): TypeGuard<TupleOfLength<N> | T2> => {
   return createTypeGuard<TupleOfLength<N> | T2>((v: unknown) =>
-    isTuple(v, length) ? v : (guard as _TypeGuard<T2>)._.parser(v, defaultHelpers)
+    isTuple(v, length) ? v : guard._.parser(v, defaultHelpers)
   );
 };
 

--- a/guardis/src/introspect.ts
+++ b/guardis/src/introspect.ts
@@ -1,20 +1,4 @@
-import type { StandardSchemaV1 } from "../specs/standard-schema-spec.v1.ts";
-import type { Context, Parser, Predicate, TypeGuard } from "./types.ts";
-
-/** Base internal metadata attached to type guards */
-export type GuardMeta<T> = {
-  _: {
-    name: string | undefined;
-    parser: Parser<T>;
-  };
-};
-
-/** Extended metadata for guards with context-aware validation */
-export type GuardWithContext<T> = GuardMeta<T> & {
-  _: {
-    context: (value: unknown, ctx?: Context) => StandardSchemaV1.Result<T>;
-  };
-};
+import type { GuardMeta, Predicate, TypeGuard } from "./types.ts";
 
 /**
  * Type guard that checks if a given guard object contains meta information.
@@ -24,7 +8,7 @@ export type GuardWithContext<T> = GuardMeta<T> & {
  */
 export const hasMeta = <T1>(
   guard: Predicate<T1> | TypeGuard<T1>,
-): guard is typeof guard & GuardMeta<T1> => {
+): guard is typeof guard & { _: GuardMeta<T1> } => {
   return "_" in guard && !!guard._ &&
     typeof guard._ === "object" && "parser" in guard._ &&
     typeof guard._.parser === "function";
@@ -36,7 +20,7 @@ export const hasMeta = <T1>(
  */
 export const hasName = <T1>(
   guard: Predicate<T1> | TypeGuard<T1>,
-): guard is typeof guard & GuardMeta<T1> & { _: { name: string } } => {
+): guard is typeof guard & { _: GuardMeta<T1> & { name: string } } => {
   return hasMeta(guard) && typeof guard._.name === "string" && guard._.name.length > 0;
 };
 
@@ -45,7 +29,7 @@ export const hasName = <T1>(
  */
 export const hasContext = <T1>(
   guard: Predicate<T1> | TypeGuard<T1>,
-): guard is typeof guard & GuardWithContext<T1> => {
+): guard is typeof guard & { _: GuardMeta<T1> } => {
   return hasMeta(guard) && "context" in guard._ &&
     typeof guard._.context === "function";
 };

--- a/guardis/src/types.ts
+++ b/guardis/src/types.ts
@@ -74,7 +74,19 @@ export type StrictTypeGuard<T> = (value: unknown, errorMsg?: string) => value is
  *
  * @template T1 The type being guarded
  */
+
+/** Internal metadata attached to type guards */
+export type GuardMeta<T> = {
+  name: string | undefined;
+  parser: Parser<T>;
+  context: (value: unknown, ctx?: Context) => StandardSchemaV1.Result<T>;
+  /** Indicates this guard is an optional variant, used by InferShape to mark properties as optional */
+  optional?: true;
+};
+
 export interface TypeGuard<T1> extends StandardSchemaV1<T1> {
+  /** Internal metadata for guard introspection */
+  _: GuardMeta<T1>;
   /**
    * A utility to gain access to the type being guarded. Can be used
    * to infer the type in other parts of the code.
@@ -158,68 +170,7 @@ export interface TypeGuard<T1> extends StandardSchemaV1<T1> {
       <T2 extends T1>(parse: ExtendedParser<T1, T2>): TypeGuard<T2>;
       <T2 extends T1>(name: string, parse: ExtendedParser<T1, T2>): TypeGuard<T2>;
     };
-  optional: {
-    /**
-     * A type guard that checks if the value is either undefined or of type T.
-     * @param value The value to check
-     * @returns true if the value is of type T or undefined, otherwise false
-     */
-    (value: unknown): value is T1 | undefined;
-    /**
-     * A strict type guard that throws an error if the value is defined but not of type T.
-     * @param value The value to check
-     * @param errorMsg Optional error message to include in the thrown error
-     * @returns true if the value is of type T, otherwise throws an error
-     */
-    strict: (value: unknown, errorMsg?: string) => value is T1 | undefined;
-    /**
-     * An assertion function that throws an error if the value is defined but not of type T.
-     * This is useful for ensuring that a value meets the type requirements at runtime.
-     *
-     * Unfortunately, TypeScript does not support the inference of assertion functions
-     * so the function must be invoked by declaring an intermediate variable and specifying
-     * the type.
-     *
-     * Example:
-     * ```typescript
-     * const value: unknown = someValue();
-     *
-     * const assertIsOptionalString: typeof isString.optional.assert = isString.optional.assert;
-     * assertIsOptionalString(value, "Expected a string or undefined");
-     * // After this line, TypeScript knows that value is a string
-     * ```
-     * @param value The value to check
-     * @param errorMsg Optional error message to include in the thrown error
-     * @returns Asserts that the value is of type T
-     */
-    assert: (value: unknown, errorMsg?: string) => asserts value is T1 | undefined;
-    /**
-     * Validates the value against the schema, accepting undefined as valid.
-     * @param value The value to validate
-     * @returns A success result with the value (including undefined), or a failure result with issues.
-     */
-    validate: (value: unknown) => StandardSchemaV1.Result<T1 | undefined>;
-    /**
-     * A type guard function that checks if the value is of type T1 | undefined | T2.
-     * This is useful for creating unions of types.
-     * @param guard A type guard for T2
-     * @returns A new type guard that checks if the value is of type T1 | undefined | T2
-     */
-    or: <Guards extends [Predicate<unknown>, ...Predicate<unknown>[]]>(
-      ...guards: Guards
-    ) => TypeGuard<T1 | undefined | PredicateUnion<Guards>>;
-    /**
-     * A type guard that checks if the value is not empty and of type T | undefined.
-     * An empty value is defined as null, an empty string, an empty array,
-     * or an empty object.
-     * @param value The value to check
-     * @returns true if the value is of type T and not empty, otherwise false
-     *
-     * @note This method is equivalent to calling `isString.notEmpty.optional`
-     * on a type guard named `isString`.
-     */
-    notEmpty: CanBeEmpty<T1> extends false ? never : TypeGuard<T1 | undefined>["notEmpty"];
-  };
+  optional: OptionalTypeGuard<T1>;
   notEmpty: CanBeEmpty<T1> extends false ? never : {
     /**
      * A type guard that checks if the value is not empty and of type T.
@@ -383,6 +334,20 @@ export interface NumberTypeGuard extends TypeGuard<number> {
   eq(target: number): NumberTypeGuard;
 }
 
+/** An optional type guard that accepts undefined in addition to the base type */
+export interface OptionalTypeGuard<T1> {
+  /** Internal metadata with optional flag for shape type inference */
+  _: Omit<GuardMeta<T1 | undefined>, "optional"> & { optional: true };
+  (value: unknown): value is T1 | undefined;
+  strict: (value: unknown, errorMsg?: string) => value is T1 | undefined;
+  assert: (value: unknown, errorMsg?: string) => asserts value is T1 | undefined;
+  validate: (value: unknown) => StandardSchemaV1.Result<T1 | undefined>;
+  or: <Guards extends [Predicate<unknown>, ...Predicate<unknown>[]]>(
+    ...guards: Guards
+  ) => TypeGuard<T1 | undefined | PredicateUnion<Guards>>;
+  notEmpty: CanBeEmpty<T1> extends false ? never : TypeGuard<T1 | undefined>["notEmpty"];
+}
+
 /** Utility type to determine if a type can be "empty" */
 export type CanBeEmpty<T> = T extends
   | null
@@ -414,12 +379,20 @@ export type TypeGuardShape = {
 // deno-lint-ignore ban-types
 export type Simplify<T> = { [K in keyof T]: T[K] } & {};
 
+/** Infer the raw type for a single shape field */
+type InferShapeField<F> = F extends (value: unknown) => value is infer T ? T
+  : F extends TypeGuardShape ? InferShape<F>
+  : F extends ShapePrimitive ? F
+  : never;
+
+/** Check if a shape field is an OptionalTypeGuard */
+type IsOptionalGuard<F> = F extends { _: { optional: true } } ? true : false;
+
 /** Recursively infers the TypeScript type from a TypeGuardShape */
 export type InferShape<S extends TypeGuardShape> = Simplify<
   {
-    -readonly [K in keyof S]: S[K] extends (value: unknown) => value is infer T ? T
-      : S[K] extends TypeGuardShape ? InferShape<S[K]>
-      : S[K] extends ShapePrimitive ? S[K]
-      : never;
+    -readonly [K in keyof S as IsOptionalGuard<S[K]> extends true ? never : K]: InferShapeField<S[K]>;
+  } & {
+    -readonly [K in keyof S as IsOptionalGuard<S[K]> extends true ? K : never]?: InferShapeField<S[K]>;
   }
 >;


### PR DESCRIPTION
## Summary
- Shape fields using `.optional` now correctly infer as optional properties (`email?: string | undefined`) instead of required properties with `undefined` in the union
- Fields using `isUndefined` remain required, preserving the distinction
- Introduces `OptionalTypeGuard<T>` interface with `_: { optional: true }` discriminant
- Consolidates `GuardMeta` into `types.ts` as a flat type, exposing guard metadata on the public `TypeGuard` interface
- Removes `GuardWithContext` and `_TypeGuard` internal types

Closes #45