### PR TITLE
Add chainable length validation methods to isArray guard

### DIFF
--- a/guardis/README.md
+++ b/guardis/README.md
@@ -59,6 +59,7 @@ npm install @spudlabs/guardis
   - [Validate Mode (StandardSchemaV1)](#validate-mode-standardschemav1)
 - [Literal Type Guards](#literal-type-guards)
 - [Numeric Comparisons](#numeric-comparisons)
+- [Array Length Validation](#array-length-validation)
 - [Creating Custom Type Guards](#creating-custom-type-guards)
 - [Extending Type Guards](#extending-type-guards)
 - [Specialized Modules](#specialized-modules)
@@ -407,6 +408,33 @@ isNumber.lt(100).validate(200); // { issues: [{ message: "Expected < 100. Receiv
 
 // Composable with or
 const isPositiveOrNull = isNumber.gt(0).or(isNull);
+```
+
+## Array Length Validation
+
+`isArray` includes chainable length validation methods:
+
+```ts
+import { isArray, isString } from "jsr:@spudlabs/guardis";
+
+// Length checks
+isArray.ofLength(3)([1, 2, 3]);  // true — exactly 3 elements
+isArray.min(1)([1]);              // true — at least 1 element
+isArray.max(5)([1, 2, 3]);       // true — at most 5 elements
+isArray.range(1, 5)([1, 2, 3]);  // true — between 1 and 5 elements
+
+// Chain for ranges
+const isSmallArray = isArray.min(1).max(5);
+
+// Compose with .of() — element type is preserved
+const isNameList = isArray.of(isString).min(1).max(10);
+isNameList(["Alice", "Bob"]); // true
+isNameList([]);                // false — too short
+isNameList([1, 2]);            // false — not strings
+
+// All modes work
+isArray.min(1).strict([]);            // throws TypeError
+isArray.max(3).validate([1, 2, 3, 4]); // { issues: [...] }
 ```
 
 ## Creating Custom Type Guards

--- a/guardis/src/guard.test.ts
+++ b/guardis/src/guard.test.ts
@@ -5341,3 +5341,126 @@ Deno.test("numeric comparison methods", async (t) => {
     assertFalse(isNumeric.gt(0)("abc"));
   });
 });
+
+Deno.test("array length methods", async (t) => {
+  await t.step("ofLength", () => {
+    assert(isArray.ofLength(3)([1, 2, 3]));
+    assertFalse(isArray.ofLength(3)([1, 2]));
+    assertFalse(isArray.ofLength(3)([1, 2, 3, 4]));
+    assertFalse(isArray.ofLength(3)("abc"));
+  });
+
+  await t.step("min", () => {
+    assert(isArray.min(1)([1]));
+    assert(isArray.min(1)([1, 2, 3]));
+    assertFalse(isArray.min(1)([]));
+    assertFalse(isArray.min(1)("a"));
+  });
+
+  await t.step("max", () => {
+    assert(isArray.max(3)([1, 2, 3]));
+    assert(isArray.max(3)([1]));
+    assert(isArray.max(3)([]));
+    assertFalse(isArray.max(3)([1, 2, 3, 4]));
+    assertFalse(isArray.max(3)("abc"));
+  });
+
+  await t.step("range", () => {
+    assert(isArray.range(1, 3)([1]));
+    assert(isArray.range(1, 3)([1, 2]));
+    assert(isArray.range(1, 3)([1, 2, 3]));
+    assertFalse(isArray.range(1, 3)([]));
+    assertFalse(isArray.range(1, 3)([1, 2, 3, 4]));
+  });
+
+  await t.step("chaining min and max", () => {
+    const between = isArray.min(1).max(5);
+    assert(between([1]));
+    assert(between([1, 2, 3, 4, 5]));
+    assertFalse(between([]));
+    assertFalse(between([1, 2, 3, 4, 5, 6]));
+  });
+
+  await t.step("validate method", () => {
+    assertEquals(isArray.min(1).validate([1, 2]), { value: [1, 2] });
+    const result = isArray.min(1).validate([]);
+    assert(!("value" in result));
+  });
+
+  await t.step("strict method", () => {
+    isArray.min(1).strict([1]);
+    assertThrows(() => isArray.min(1).strict([]));
+  });
+
+  await t.step("of with length methods", () => {
+    const guard = isArray.of(isString).min(1);
+    assert(guard(["a"]));
+    assert(guard(["a", "b"]));
+    assertFalse(guard([]));
+    assertFalse(guard([1]));
+    type Guarded = typeof guard._TYPE;
+    assertType<Equals<Guarded, string[]>>();
+  });
+
+  await t.step("of with chained min and max", () => {
+    const guard = isArray.of(isNumber).min(2).max(4);
+    assert(guard([1, 2]));
+    assert(guard([1, 2, 3, 4]));
+    assertFalse(guard([1]));
+    assertFalse(guard([1, 2, 3, 4, 5]));
+  });
+
+  await t.step("of with range", () => {
+    const guard = isArray.of(isString).range(1, 3);
+    assert(guard(["a"]));
+    assert(guard(["a", "b", "c"]));
+    assertFalse(guard([]));
+    assertFalse(guard(["a", "b", "c", "d"]));
+    type Guarded = typeof guard._TYPE;
+    assertType<Equals<Guarded, string[]>>();
+  });
+
+  await t.step("or after length method", () => {
+    const guard = isArray.min(1).or(isNull);
+    assert(guard([1]));
+    assert(guard(null));
+    assertFalse(guard([]));
+    assertFalse(guard(undefined));
+  });
+
+  await t.step("optional after length method", () => {
+    const guard = isArray.min(1).optional;
+    assert(guard([1]));
+    assert(guard(undefined));
+    assertFalse(guard([]));
+    assertFalse(guard(null));
+  });
+
+  await t.step("extend after length method", () => {
+    const guard = isArray.of(isNumber).min(1).extend((v) =>
+      v.every((n) => n > 0) ? v : null
+    );
+    assert(guard([1, 2, 3]));
+    assertFalse(guard([]));
+    assertFalse(guard([-1, 2]));
+  });
+
+  await t.step("length methods in shape definition", () => {
+    const isForm = createTypeGuard({
+      tags: isArray.of(isString).min(1).max(5),
+      name: isString,
+    });
+    assert(isForm({ tags: ["a"], name: "test" }));
+    assertFalse(isForm({ tags: [], name: "test" }));
+    assertFalse(isForm({ tags: ["a", "b", "c", "d", "e", "f"], name: "test" }));
+  });
+
+  await t.step("validate with shape and length methods", () => {
+    const isForm = createTypeGuard({
+      items: isArray.of(isNumber).min(1),
+    });
+    assertEquals(isForm.validate({ items: [1, 2] }), { value: { items: [1, 2] } });
+    const result = isForm.validate({ items: [] });
+    assert(!("value" in result));
+  });
+});

--- a/guardis/src/guard.test.ts
+++ b/guardis/src/guard.test.ts
@@ -5383,8 +5383,25 @@ Deno.test("array length methods", async (t) => {
 
   await t.step("validate method", () => {
     assertEquals(isArray.min(1).validate([1, 2]), { value: [1, 2] });
-    const result = isArray.min(1).validate([]);
-    assert(!("value" in result));
+    assertEquals(isArray.min(1).validate([]), {
+      issues: [{ message: "Expected length >= 1. Received: []" }],
+    });
+    assertEquals(isArray.max(2).validate([1, 2, 3]), {
+      issues: [{ message: "Expected length <= 2. Received: [1,2,3]" }],
+    });
+    assertEquals(isArray.ofLength(2).validate([1]), {
+      issues: [{ message: "Expected length == 2. Received: [1]" }],
+    });
+    assertEquals(isArray.range(2, 4).validate([1]), {
+      issues: [{ message: "Expected length 2..4. Received: [1]" }],
+    });
+    assertEquals(isArray.range(2, 4).validate([1, 2, 3, 4, 5]), {
+      issues: [{ message: "Expected length 2..4. Received: [1,2,3,4,5]" }],
+    });
+    // non-array input
+    assertEquals(isArray.min(1).validate("not an array"), {
+      issues: [{ message: "Expected length >= 1. Received: 'not an array'" }],
+    });
   });
 
   await t.step("strict method", () => {

--- a/guardis/src/guard.ts
+++ b/guardis/src/guard.ts
@@ -5,6 +5,7 @@
 
 import type { StandardSchemaV1 } from "../specs/standard-schema-spec.v1.ts";
 import type {
+  ArrayTypeGuard,
   CanBeEmpty,
   Context,
   ExtendedParser,
@@ -778,21 +779,33 @@ export const isJsonObject: TypeGuard<JsonObject> = createTypeGuard(
 const _isArray = createTypeGuard("array", (t): unknown[] | null => Array.isArray(t) ? t : null);
 
 /**
+ * Wraps a TypeGuard<T[]> with chainable length validation methods.
+ * Each method delegates to .extend() and wraps the result for further chaining.
+ */
+function withArrayMethods<T>(guard: TypeGuard<T[]>): ArrayTypeGuard<T> {
+  const arr = guard as ArrayTypeGuard<T>;
+  arr.ofLength = (n) =>
+    withArrayMethods(guard.extend(`length == ${n}`, (v) => v.length === n ? v : null));
+  arr.min = (n) =>
+    withArrayMethods(guard.extend(`length >= ${n}`, (v) => v.length >= n ? v : null));
+  arr.max = (n) =>
+    withArrayMethods(guard.extend(`length <= ${n}`, (v) => v.length <= n ? v : null));
+  arr.range = (min, max) =>
+    withArrayMethods(
+      guard.extend(`length ${min}..${max}`, (v) => v.length >= min && v.length <= max ? v : null),
+    );
+  return arr;
+}
+
+/**
  * Returns true if input satisfies type array.
  * @param {unknown} t
  * @return {boolean}
  */
-export const isArray: TypeGuard<unknown[]> & {
-  /**
-   * Returns true if input satisfies type array of T.
-   * @param guard The type guard for the array elements
-   * @returns {boolean}
-   */
-  of: <T>(guard: TypeGuard<T>) => TypeGuard<T[]>;
-} = Object.assign(
+export const isArray: ArrayTypeGuard = withArrayMethods(Object.assign(
   _isArray,
   {
-    of: <T>(guard: TypeGuard<T>): TypeGuard<T[]> => {
+    of: <T>(guard: TypeGuard<T>): ArrayTypeGuard<T> => {
       const guardName = hasName(guard) ? guard._.name : undefined;
 
       let name = "array";
@@ -801,7 +814,7 @@ export const isArray: TypeGuard<unknown[]> & {
         name = guardName?.includes(" | ") ? `(${guardName})[]` : `${guardName}[]`;
       }
 
-      return createTypeGuard(
+      return withArrayMethods(createTypeGuard(
         name,
         (v, helpers) => {
           if (!isArray(v)) return null;
@@ -821,10 +834,10 @@ export const isArray: TypeGuard<unknown[]> & {
           // Otherwise, use simple boolean check
           return v.every((item) => guard(item)) ? v as T[] : null;
         },
-      );
+      ));
     },
   },
-);
+));
 
 /**
  * Returns true if input satisfies type array.

--- a/guardis/src/types.ts
+++ b/guardis/src/types.ts
@@ -334,6 +334,20 @@ export interface NumberTypeGuard extends TypeGuard<number> {
   eq(target: number): NumberTypeGuard;
 }
 
+/** An array type guard with chainable length validation methods */
+export interface ArrayTypeGuard<T = unknown> extends TypeGuard<T[]> {
+  /** Returns a typed array guard preserving length methods */
+  of<U>(guard: TypeGuard<U>): ArrayTypeGuard<U>;
+  /** Checks array has exactly this length */
+  ofLength(length: number): ArrayTypeGuard<T>;
+  /** Checks array length >= min */
+  min(length: number): ArrayTypeGuard<T>;
+  /** Checks array length <= max */
+  max(length: number): ArrayTypeGuard<T>;
+  /** Checks array length is between min and max (inclusive) */
+  range(min: number, max: number): ArrayTypeGuard<T>;
+}
+
 /** An optional type guard that accepts undefined in addition to the base type */
 export interface OptionalTypeGuard<T1> {
   /** Internal metadata with optional flag for shape type inference */


### PR DESCRIPTION
## Summary
- Adds `ofLength`, `min`, `max`, and `range` methods to `isArray` via new `ArrayTypeGuard<T>` interface
- Methods chain naturally: `isArray.min(1).max(5)`
- Composes with `.of()` preserving element types: `isArray.of(isString).min(1)` yields `ArrayTypeGuard<string>`
- `range(min, max)` is shorthand for `.min(min).max(max)`
- Works with all guard modes (strict, validate, optional, or, extend) and in shape definitions

Closes #44