### PR TITLE
Add comparative benchmarks against Zod, ArkType, and Valibot

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,9 @@
 {
-  "workspace": ["packages/guardis/", "packages/guardis-hono/"],
+  "workspace": ["packages/guardis/", "packages/guardis-hono/", "packages/benchmarks/"],
   "tasks": {
     "test": "cd packages/guardis && deno task test && cd ../guardis-hono && deno task test",
+    "bench": "cd packages/benchmarks && deno bench",
+    "bench:guards": "cd packages/guardis && deno task bench:all",
     "build:guardis": "cd packages/guardis && deno run -A scripts/build_npm.ts",
     "build:hono": "cd packages/guardis-hono && deno run -A scripts/build_npm.ts",
     "build:npm": "deno task build:guardis && deno task build:hono"

--- a/import_map.json
+++ b/import_map.json
@@ -6,6 +6,10 @@
     "hono/": "npm:/hono@^4.10.0/",
 
     "@spudlabs/guardis": "./packages/guardis/mod.ts",
-    "@spudlabs/guardis-hono": "./packages/guardis-hono/mod.ts"
+    "@spudlabs/guardis-hono": "./packages/guardis-hono/mod.ts",
+
+    "zod": "npm:zod@^3",
+    "arktype": "npm:arktype@^2",
+    "valibot": "npm:valibot@^1"
   }
 }

--- a/packages/benchmarks/arktype/object-schema.bench.ts
+++ b/packages/benchmarks/arktype/object-schema.bench.ts
@@ -1,0 +1,13 @@
+import { type } from "arktype";
+import { INVALID_USER, VALID_USER } from "../data/object-schema.ts";
+
+const User = type({
+  name: "string",
+  age: "number",
+  active: "boolean",
+  score: "number",
+  "email?": "string",
+});
+
+Deno.bench({ name: "arktype: object (valid)", fn() { User(VALID_USER); } });
+Deno.bench({ name: "arktype: object (invalid)", fn() { User(INVALID_USER); } });

--- a/packages/benchmarks/arktype/primitives.bench.ts
+++ b/packages/benchmarks/arktype/primitives.bench.ts
@@ -1,0 +1,20 @@
+import { type } from "arktype";
+import {
+  INVALID_BOOLEAN,
+  INVALID_NUMBER,
+  INVALID_STRING,
+  VALID_BOOLEAN,
+  VALID_NUMBER,
+  VALID_STRING,
+} from "../data/primitives.ts";
+
+const arkString = type("string");
+const arkNumber = type("number");
+const arkBoolean = type("boolean");
+
+Deno.bench({ name: "arktype: string (valid)", fn() { arkString(VALID_STRING); } });
+Deno.bench({ name: "arktype: string (invalid)", fn() { arkString(INVALID_STRING); } });
+Deno.bench({ name: "arktype: number (valid)", fn() { arkNumber(VALID_NUMBER); } });
+Deno.bench({ name: "arktype: number (invalid)", fn() { arkNumber(INVALID_NUMBER); } });
+Deno.bench({ name: "arktype: boolean (valid)", fn() { arkBoolean(VALID_BOOLEAN); } });
+Deno.bench({ name: "arktype: boolean (invalid)", fn() { arkBoolean(INVALID_BOOLEAN); } });

--- a/packages/benchmarks/arktype/real-world.bench.ts
+++ b/packages/benchmarks/arktype/real-world.bench.ts
@@ -1,0 +1,32 @@
+import { type } from "arktype";
+import { INVALID_API_REQUEST, VALID_API_REQUEST } from "../data/real-world.ts";
+
+const ApiRequest = type({
+  user: {
+    name: "string",
+    email: "string",
+    age: "number",
+    active: "boolean",
+  },
+  address: {
+    street: "string",
+    city: "string",
+    state: "string",
+    zip: "string",
+  },
+  tags: "string[]",
+  metadata: {
+    source: "string",
+    version: "number",
+    referral: "string",
+  },
+});
+
+Deno.bench({
+  name: "arktype: real-world (valid)",
+  fn() { ApiRequest(VALID_API_REQUEST); },
+});
+Deno.bench({
+  name: "arktype: real-world (invalid)",
+  fn() { ApiRequest(INVALID_API_REQUEST); },
+});

--- a/packages/benchmarks/data/object-schema.ts
+++ b/packages/benchmarks/data/object-schema.ts
@@ -1,0 +1,23 @@
+// Flat DTO shape: { name: string, age: number, active: boolean, score: number, email?: string }
+export const VALID_USER = {
+  name: "Alice",
+  age: 30,
+  active: true,
+  score: 95.5,
+  email: "alice@example.com",
+};
+
+export const VALID_USER_MINIMAL = {
+  name: "Bob",
+  age: 25,
+  active: false,
+  score: 80.0,
+};
+
+export const INVALID_USER = {
+  name: 123,
+  age: "thirty",
+  active: "yes",
+  score: null,
+  email: 42,
+};

--- a/packages/benchmarks/data/primitives.ts
+++ b/packages/benchmarks/data/primitives.ts
@@ -1,0 +1,9 @@
+// Valid inputs
+export const VALID_STRING = "hello world";
+export const VALID_NUMBER = 42;
+export const VALID_BOOLEAN = true;
+
+// Invalid inputs (wrong type for each check)
+export const INVALID_STRING = 12345;
+export const INVALID_NUMBER = "not a number";
+export const INVALID_BOOLEAN = "true";

--- a/packages/benchmarks/data/real-world.ts
+++ b/packages/benchmarks/data/real-world.ts
@@ -1,0 +1,42 @@
+// Realistic nested API request payload
+export const VALID_API_REQUEST = {
+  user: {
+    name: "Alice Johnson",
+    email: "alice@example.com",
+    age: 30,
+    active: true,
+  },
+  address: {
+    street: "123 Main St",
+    city: "Springfield",
+    state: "IL",
+    zip: "62701",
+  },
+  tags: ["admin", "verified", "premium"],
+  metadata: {
+    source: "web",
+    version: 2,
+    referral: "campaign-123",
+  },
+};
+
+export const INVALID_API_REQUEST = {
+  user: {
+    name: 42,
+    email: true,
+    age: "old",
+    active: "yes",
+  },
+  address: {
+    street: 100,
+    city: null,
+    state: 5,
+    zip: false,
+  },
+  tags: "not-an-array",
+  metadata: {
+    source: 999,
+    version: "two",
+    referral: null,
+  },
+};

--- a/packages/benchmarks/deno.json
+++ b/packages/benchmarks/deno.json
@@ -1,0 +1,14 @@
+{
+  "name": "@spudlabs/guardis-benchmarks",
+  "version": "0.0.0",
+  "description": "Comparative benchmarks for Guardis against Zod, ArkType, and Valibot.",
+  "exports": {},
+  "tasks": {
+    "bench": "deno bench",
+    "format": "deno run -A scripts/format-results.ts"
+  },
+  "compilerOptions": {},
+  "fmt": {
+    "lineWidth": 100
+  }
+}

--- a/packages/benchmarks/guardis/object-schema.bench.ts
+++ b/packages/benchmarks/guardis/object-schema.bench.ts
@@ -1,0 +1,13 @@
+import { createTypeGuard, isBoolean, isNumber, isString } from "@spudlabs/guardis";
+import { INVALID_USER, VALID_USER } from "../data/object-schema.ts";
+
+const isUser = createTypeGuard({
+  name: isString,
+  age: isNumber,
+  active: isBoolean,
+  score: isNumber,
+  email: isString.optional,
+});
+
+Deno.bench({ name: "guardis: object (valid)", fn() { isUser(VALID_USER); } });
+Deno.bench({ name: "guardis: object (invalid)", fn() { isUser(INVALID_USER); } });

--- a/packages/benchmarks/guardis/primitives.bench.ts
+++ b/packages/benchmarks/guardis/primitives.bench.ts
@@ -1,0 +1,16 @@
+import { isBoolean, isNumber, isString } from "@spudlabs/guardis";
+import {
+  INVALID_BOOLEAN,
+  INVALID_NUMBER,
+  INVALID_STRING,
+  VALID_BOOLEAN,
+  VALID_NUMBER,
+  VALID_STRING,
+} from "../data/primitives.ts";
+
+Deno.bench({ name: "guardis: string (valid)", fn() { isString(VALID_STRING); } });
+Deno.bench({ name: "guardis: string (invalid)", fn() { isString(INVALID_STRING); } });
+Deno.bench({ name: "guardis: number (valid)", fn() { isNumber(VALID_NUMBER); } });
+Deno.bench({ name: "guardis: number (invalid)", fn() { isNumber(INVALID_NUMBER); } });
+Deno.bench({ name: "guardis: boolean (valid)", fn() { isBoolean(VALID_BOOLEAN); } });
+Deno.bench({ name: "guardis: boolean (invalid)", fn() { isBoolean(INVALID_BOOLEAN); } });

--- a/packages/benchmarks/guardis/real-world.bench.ts
+++ b/packages/benchmarks/guardis/real-world.bench.ts
@@ -1,0 +1,35 @@
+import {
+  createTypeGuard,
+  isArray,
+  isBoolean,
+  isNumber,
+  isString,
+} from "@spudlabs/guardis";
+import { INVALID_API_REQUEST, VALID_API_REQUEST } from "../data/real-world.ts";
+
+const isApiRequest = createTypeGuard({
+  user: createTypeGuard({
+    name: isString,
+    email: isString,
+    age: isNumber,
+    active: isBoolean,
+  }),
+  address: createTypeGuard({
+    street: isString,
+    city: isString,
+    state: isString,
+    zip: isString,
+  }),
+  tags: isArray(isString),
+  metadata: createTypeGuard({
+    source: isString,
+    version: isNumber,
+    referral: isString,
+  }),
+});
+
+Deno.bench({ name: "guardis: real-world (valid)", fn() { isApiRequest(VALID_API_REQUEST); } });
+Deno.bench({
+  name: "guardis: real-world (invalid)",
+  fn() { isApiRequest(INVALID_API_REQUEST); },
+});

--- a/packages/benchmarks/scripts/format-results.ts
+++ b/packages/benchmarks/scripts/format-results.ts
@@ -1,0 +1,163 @@
+/**
+ * Runs `deno bench --json` and formats results as markdown comparison tables.
+ * Guardis is the 1.0x baseline; other libraries show relative performance.
+ *
+ * Usage: deno run -A scripts/format-results.ts
+ */
+
+interface BenchResult {
+  ok?: {
+    n: number;
+    avg: number;
+    min: number;
+    max: number;
+    p75: number;
+    p99: number;
+    highPrecision: boolean;
+  };
+  error?: unknown;
+}
+
+interface BenchEntry {
+  origin: string;
+  name: string;
+  results: BenchResult[];
+}
+
+interface BenchOutput {
+  version: number;
+  runtime: string;
+  cpu: string;
+  benches: BenchEntry[];
+}
+
+interface ParsedResult {
+  library: string;
+  scenario: string;
+  benchName: string;
+  path: string;
+  opsPerSec: number;
+}
+
+function identifyLibrary(origin: string): string | null {
+  const match = origin.match(/\/benchmarks\/(guardis|zod|arktype|valibot)\//);
+  return match ? match[1] : null;
+}
+
+const SCENARIO_ORDER = ["primitives", "object-schema", "real-world"];
+
+function identifyScenario(origin: string): string | null {
+  for (const scenario of SCENARIO_ORDER) {
+    if (origin.includes(`${scenario}.bench.ts`)) return scenario;
+  }
+  return null;
+}
+
+function parseBenchName(name: string): { benchName: string; path: string } {
+  const match = name.match(/^\w+:\s+(.+?)\s+\((valid|invalid)\)$/);
+  if (match) return { benchName: match[1], path: match[2] };
+  return { benchName: name, path: "unknown" };
+}
+
+function computeOpsPerSec(result: BenchResult): number | null {
+  if (!result.ok) return null;
+  const { avg, highPrecision } = result.ok;
+  return highPrecision ? 1_000_000_000 / avg : 1_000_000 / avg;
+}
+
+function formatOps(ops: number): string {
+  if (ops >= 1_000_000_000) return `${(ops / 1_000_000_000).toFixed(2)}B`;
+  if (ops >= 1_000_000) return `${(ops / 1_000_000).toFixed(2)}M`;
+  if (ops >= 1_000) return `${(ops / 1_000).toFixed(2)}K`;
+  return ops.toFixed(0);
+}
+
+function formatRelative(opsPerSec: number, baseline: number, library: string): string {
+  if (library === "guardis") return "baseline";
+  const ratio = opsPerSec / baseline;
+  return `${ratio.toFixed(2)}x`;
+}
+
+async function main() {
+  const cmd = new Deno.Command("deno", {
+    args: ["bench", "--json"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { code, stdout, stderr } = await cmd.output();
+
+  if (code !== 0) {
+    console.error("deno bench failed:");
+    console.error(new TextDecoder().decode(stderr));
+    Deno.exit(1);
+  }
+
+  const data: BenchOutput = JSON.parse(new TextDecoder().decode(stdout));
+
+  console.log(`# Benchmark Results\n`);
+  console.log(`- **Runtime:** ${data.runtime}`);
+  console.log(`- **CPU:** ${data.cpu}\n`);
+
+  // Parse all results
+  const parsed: ParsedResult[] = [];
+  for (const bench of data.benches) {
+    const library = identifyLibrary(bench.origin);
+    const scenario = identifyScenario(bench.origin);
+    if (!library || !scenario) continue;
+
+    const { benchName, path } = parseBenchName(bench.name);
+
+    for (const result of bench.results) {
+      const opsPerSec = computeOpsPerSec(result);
+      if (opsPerSec === null) continue;
+
+      parsed.push({ library, scenario, benchName, path, opsPerSec });
+    }
+  }
+
+  for (const scenario of SCENARIO_ORDER) {
+    const scenarioResults = parsed.filter((r) => r.scenario === scenario);
+    if (scenarioResults.length === 0) continue;
+
+    const title = scenario.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+    console.log(`## ${title}\n`);
+
+    // Get unique bench names preserving order of first appearance
+    const benchNames: string[] = [];
+    for (const r of scenarioResults) {
+      if (!benchNames.includes(r.benchName)) benchNames.push(r.benchName);
+    }
+
+    // Get unique paths
+    const paths = [...new Set(scenarioResults.map((r) => r.path))].sort();
+
+    for (const path of paths) {
+      console.log(`### ${path === "valid" ? "Valid Input" : "Invalid Input"}\n`);
+      console.log("| Benchmark | Guardis | Zod | ArkType | Valibot |");
+      console.log("|-----------|---------|-----|---------|---------|");
+
+      for (const benchName of benchNames) {
+        const row = parsed.filter(
+          (r) => r.scenario === scenario && r.benchName === benchName && r.path === path,
+        );
+        if (row.length === 0) continue;
+
+        const guardisOps = row.find((r) => r.library === "guardis")?.opsPerSec ?? 0;
+
+        const cells = ["guardis", "zod", "arktype", "valibot"].map((lib) => {
+          const result = row.find((r) => r.library === lib);
+          if (!result) return "-";
+          const ops = formatOps(result.opsPerSec);
+          const rel = formatRelative(result.opsPerSec, guardisOps, lib);
+          return `${ops} (${rel})`;
+        });
+
+        console.log(`| ${benchName} | ${cells.join(" | ")} |`);
+      }
+      console.log("");
+    }
+  }
+}
+
+main();

--- a/packages/benchmarks/valibot/object-schema.bench.ts
+++ b/packages/benchmarks/valibot/object-schema.bench.ts
@@ -1,0 +1,16 @@
+import * as v from "valibot";
+import { INVALID_USER, VALID_USER } from "../data/object-schema.ts";
+
+const UserSchema = v.object({
+  name: v.string(),
+  age: v.number(),
+  active: v.boolean(),
+  score: v.number(),
+  email: v.optional(v.string()),
+});
+
+Deno.bench({ name: "valibot: object (valid)", fn() { v.safeParse(UserSchema, VALID_USER); } });
+Deno.bench({
+  name: "valibot: object (invalid)",
+  fn() { v.safeParse(UserSchema, INVALID_USER); },
+});

--- a/packages/benchmarks/valibot/primitives.bench.ts
+++ b/packages/benchmarks/valibot/primitives.bench.ts
@@ -1,0 +1,23 @@
+import * as v from "valibot";
+import {
+  INVALID_BOOLEAN,
+  INVALID_NUMBER,
+  INVALID_STRING,
+  VALID_BOOLEAN,
+  VALID_NUMBER,
+  VALID_STRING,
+} from "../data/primitives.ts";
+
+const vString = v.string();
+const vNumber = v.number();
+const vBoolean = v.boolean();
+
+Deno.bench({ name: "valibot: string (valid)", fn() { v.safeParse(vString, VALID_STRING); } });
+Deno.bench({ name: "valibot: string (invalid)", fn() { v.safeParse(vString, INVALID_STRING); } });
+Deno.bench({ name: "valibot: number (valid)", fn() { v.safeParse(vNumber, VALID_NUMBER); } });
+Deno.bench({ name: "valibot: number (invalid)", fn() { v.safeParse(vNumber, INVALID_NUMBER); } });
+Deno.bench({ name: "valibot: boolean (valid)", fn() { v.safeParse(vBoolean, VALID_BOOLEAN); } });
+Deno.bench({
+  name: "valibot: boolean (invalid)",
+  fn() { v.safeParse(vBoolean, INVALID_BOOLEAN); },
+});

--- a/packages/benchmarks/valibot/real-world.bench.ts
+++ b/packages/benchmarks/valibot/real-world.bench.ts
@@ -1,0 +1,32 @@
+import * as v from "valibot";
+import { INVALID_API_REQUEST, VALID_API_REQUEST } from "../data/real-world.ts";
+
+const ApiRequestSchema = v.object({
+  user: v.object({
+    name: v.string(),
+    email: v.string(),
+    age: v.number(),
+    active: v.boolean(),
+  }),
+  address: v.object({
+    street: v.string(),
+    city: v.string(),
+    state: v.string(),
+    zip: v.string(),
+  }),
+  tags: v.array(v.string()),
+  metadata: v.object({
+    source: v.string(),
+    version: v.number(),
+    referral: v.string(),
+  }),
+});
+
+Deno.bench({
+  name: "valibot: real-world (valid)",
+  fn() { v.safeParse(ApiRequestSchema, VALID_API_REQUEST); },
+});
+Deno.bench({
+  name: "valibot: real-world (invalid)",
+  fn() { v.safeParse(ApiRequestSchema, INVALID_API_REQUEST); },
+});

--- a/packages/benchmarks/zod/object-schema.bench.ts
+++ b/packages/benchmarks/zod/object-schema.bench.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { INVALID_USER, VALID_USER } from "../data/object-schema.ts";
+
+const UserSchema = z.object({
+  name: z.string(),
+  age: z.number(),
+  active: z.boolean(),
+  score: z.number(),
+  email: z.string().optional(),
+});
+
+Deno.bench({ name: "zod: object (valid)", fn() { UserSchema.safeParse(VALID_USER); } });
+Deno.bench({ name: "zod: object (invalid)", fn() { UserSchema.safeParse(INVALID_USER); } });

--- a/packages/benchmarks/zod/primitives.bench.ts
+++ b/packages/benchmarks/zod/primitives.bench.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import {
+  INVALID_BOOLEAN,
+  INVALID_NUMBER,
+  INVALID_STRING,
+  VALID_BOOLEAN,
+  VALID_NUMBER,
+  VALID_STRING,
+} from "../data/primitives.ts";
+
+const zString = z.string();
+const zNumber = z.number();
+const zBoolean = z.boolean();
+
+Deno.bench({ name: "zod: string (valid)", fn() { zString.safeParse(VALID_STRING); } });
+Deno.bench({ name: "zod: string (invalid)", fn() { zString.safeParse(INVALID_STRING); } });
+Deno.bench({ name: "zod: number (valid)", fn() { zNumber.safeParse(VALID_NUMBER); } });
+Deno.bench({ name: "zod: number (invalid)", fn() { zNumber.safeParse(INVALID_NUMBER); } });
+Deno.bench({ name: "zod: boolean (valid)", fn() { zBoolean.safeParse(VALID_BOOLEAN); } });
+Deno.bench({ name: "zod: boolean (invalid)", fn() { zBoolean.safeParse(INVALID_BOOLEAN); } });

--- a/packages/benchmarks/zod/real-world.bench.ts
+++ b/packages/benchmarks/zod/real-world.bench.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import { INVALID_API_REQUEST, VALID_API_REQUEST } from "../data/real-world.ts";
+
+const ApiRequestSchema = z.object({
+  user: z.object({
+    name: z.string(),
+    email: z.string(),
+    age: z.number(),
+    active: z.boolean(),
+  }),
+  address: z.object({
+    street: z.string(),
+    city: z.string(),
+    state: z.string(),
+    zip: z.string(),
+  }),
+  tags: z.array(z.string()),
+  metadata: z.object({
+    source: z.string(),
+    version: z.number(),
+    referral: z.string(),
+  }),
+});
+
+Deno.bench({
+  name: "zod: real-world (valid)",
+  fn() { ApiRequestSchema.safeParse(VALID_API_REQUEST); },
+});
+Deno.bench({
+  name: "zod: real-world (invalid)",
+  fn() { ApiRequestSchema.safeParse(INVALID_API_REQUEST); },
+});


### PR DESCRIPTION
## Summary

- New `packages/benchmarks/` workspace member with comparative benchmarks against Zod, ArkType, and Valibot
- Three scenarios: primitives, object schemas, and real-world nested payloads, each testing valid and invalid input paths
- Formatting script that produces markdown comparison tables from `deno bench --json` output
- Root-level `deno task bench` (comparative) and `deno task bench:guards` (internal) tasks

## Test plan

- [x] All existing tests pass (`deno task test`)
- [x] All 40 benchmark entries run successfully across all four libraries
- [x] Formatting script produces correct markdown tables with Guardis as 1.0x baseline
- [x] Root `bench:guards` task correctly delegates to existing internal benchmarks