### PR TITLE
Align with current Standard Schema V1 spec

### DIFF
--- a/packages/guardis/specs/standard-schema-spec.v1.ts
+++ b/packages/guardis/specs/standard-schema-spec.v1.ts
@@ -12,13 +12,22 @@ export declare namespace StandardSchemaV1 {
     /** The vendor name of the schema library. */
     readonly vendor: string;
     /** Validates unknown input values. */
-    readonly validate: (value: unknown) => Result<Output> | Promise<Result<Output>>;
+    readonly validate: (
+      value: unknown,
+      options?: StandardSchemaV1.Options | undefined,
+    ) => Result<Output> | Promise<Result<Output>>;
     /** Inferred types associated with the schema. */
     readonly types?: Types<Input, Output> | undefined;
   }
 
   /** The result interface of the validate function. */
   export type Result<Output> = SuccessResult<Output> | FailureResult;
+
+  /** The options interface for the validate function. */
+  export interface Options {
+    /** Vendor-specific parameters. */
+    readonly libraryOptions?: Record<string, unknown> | undefined;
+  }
 
   /** The result interface if validation succeeds. */
   export interface SuccessResult<Output> {

--- a/packages/guardis/src/guard.test.ts
+++ b/packages/guardis/src/guard.test.ts
@@ -1,4 +1,5 @@
 import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
+import type { StandardSchemaV1 } from "../specs/standard-schema-spec.v1.ts";
 import {
   createTypeGuard,
   isArray,
@@ -2712,6 +2713,10 @@ Deno.test("createTypeGuard", async (t) => {
     assert(isPositiveNumber["~standard"]);
     assertEquals(isPositiveNumber["~standard"].version, 1);
     assertEquals(isPositiveNumber["~standard"].vendor, "guardis");
+    assert(isPositiveNumber["~standard"].types !== undefined);
+
+    // InferOutput resolves to the guarded type
+    assertType<Equals<StandardSchemaV1.InferOutput<typeof isPositiveNumber>, number>>();
   });
 });
 
@@ -4324,6 +4329,13 @@ Deno.test("createTypeGuard shape", async (t) => {
       const directResult = isPersonShape.validate(input);
       const standardResult = isPersonShape["~standard"].validate(input);
       assertEquals(directResult, standardResult);
+    });
+
+    await t.step("~standard.types exists for external InferInput/InferOutput", () => {
+      assert(isPersonShape["~standard"].types !== undefined);
+      assertType<
+        Equals<StandardSchemaV1.InferOutput<typeof isPersonShape>, { name: string; age: number }>
+      >();
     });
   });
 

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -723,7 +723,8 @@ export function createTypeGuard<T1>(
     version: 1,
     vendor: "guardis",
     validate: callback.validate,
-  } as const;
+    types: {} as StandardSchemaV1.Types<T1>,
+  };
 
   // Attach the type to the function for easy access
   return (<T1>(t: unknown): TypeGuard<T1> => t as TypeGuard<T1>)(callback);


### PR DESCRIPTION
## Summary

- Add `Options` interface and optional second parameter to `validate` signature in the spec file, matching the [current Standard Schema V1 definition](https://standardschema.dev/schema)
- Add `types` property to the `~standard` object on every TypeGuard so external consumers can use `StandardSchemaV1.InferInput` / `InferOutput` for type extraction
- Add tests verifying `~standard.types` exists at runtime and that `InferOutput` resolves to the correct type at compile time via `assertType<Equals<...>>`

## What was non-compliant

1. **`validate` signature** was missing the optional `options` parameter defined in the current spec
2. **`types` property** was absent from `~standard`, so `InferInput`/`InferOutput` from external Standard Schema consumers would not resolve

Both are now fixed. All existing tests pass unchanged, plus 1 new test step per guard type.

## Test plan

- [x] All 99 guardis tests (676 steps) pass
- [x] All 24 guardis-hono tests pass
- [x] `InferOutput<typeof guard>` resolves correctly for both parser-based and shape-based guards (verified via `assertType<Equals<...>>`)