### PR TITLE
Add isRecord factory guard

### DIFF
--- a/packages/guardis/mod.ts
+++ b/packages/guardis/mod.ts
@@ -44,4 +44,5 @@ export const Is = {
   Tuple: g.isTuple,
   Date: g.isDate,
   Exactly: g.isExactly,
+  Record: g.isRecord,
 } as const;

--- a/packages/guardis/src/guard.test.ts
+++ b/packages/guardis/src/guard.test.ts
@@ -20,6 +20,7 @@ import {
   isNumeric,
   isObject,
   isPropertyKey,
+  isRecord,
   isString,
   isSymbol,
   isTuple,
@@ -5646,5 +5647,69 @@ Deno.test("createTypeGuard with verified shape (explicit type parameter)", async
     assert(isPositive(5));
     assertFalse(isPositive(-1));
     assertType<Equals<typeof isPositive._TYPE, number>>();
+  });
+});
+
+Deno.test("isRecord", async (t) => {
+  await t.step("accepts record with matching values", () => {
+    assert(isRecord(isString)({ a: "foo", b: "bar" }));
+  });
+
+  await t.step("rejects record with non-matching values", () => {
+    assertFalse(isRecord(isString)({ a: "foo", b: 42 }));
+  });
+
+  await t.step("accepts record with number values", () => {
+    assert(isRecord(isNumber)({ x: 1, y: 2 }));
+  });
+
+  await t.step("accepts empty object", () => {
+    assert(isRecord(isString)({}));
+  });
+
+  await t.step("rejects null", () => {
+    assertFalse(isRecord(isString)(null));
+  });
+
+  await t.step("rejects array", () => {
+    assertFalse(isRecord(isString)([1, 2, 3]));
+  });
+
+  await t.step("rejects non-object", () => {
+    assertFalse(isRecord(isString)("not object"));
+  });
+
+  await t.step("validate returns issues with path", () => {
+    const result = isRecord(isString).validate({ a: "ok", b: 42 });
+    assert("issues" in result);
+    if ("issues" in result) {
+      assert(result.issues!.length > 0);
+      const paths = result.issues!.map((i) => i.path);
+      assert(paths.some((p) => p !== undefined && p.includes("b")));
+    }
+  });
+
+  await t.step("strict throws on invalid value", () => {
+    assertThrows(() => isRecord(isString).strict({ a: 42 }));
+  });
+
+  await t.step("optional accepts undefined", () => {
+    assert(isRecord(isString).optional(undefined));
+  });
+
+  await t.step("works inside a shape", () => {
+    const isConfig = createTypeGuard({ env: isRecord(isString) });
+    assert(isConfig({ env: { NODE_ENV: "prod" } }));
+    assertFalse(isConfig({ env: { NODE_ENV: 123 } }));
+  });
+
+  await t.step("two-arg form validates keys", () => {
+    const isEnvKey = createTypeGuard<"NODE_ENV" | "PORT">("EnvKey", (v) => {
+      if (v === "NODE_ENV" || v === "PORT") return v;
+      return null;
+    });
+    const guard = isRecord(isEnvKey, isString);
+    assert(guard({ NODE_ENV: "prod", PORT: "3000" }));
+    assertFalse(guard({ INVALID_KEY: "value" }));
   });
 });

--- a/packages/guardis/src/guard.test.ts
+++ b/packages/guardis/src/guard.test.ts
@@ -5651,36 +5651,44 @@ Deno.test("createTypeGuard with verified shape (explicit type parameter)", async
 });
 
 Deno.test("isRecord", async (t) => {
-  await t.step("accepts record with matching values", () => {
-    assert(isRecord(isString)({ a: "foo", b: "bar" }));
+  await t.step("base guard accepts plain objects", () => {
+    assert(isRecord({ a: 1, b: "two" }));
+    assert(isRecord({}));
   });
 
-  await t.step("rejects record with non-matching values", () => {
-    assertFalse(isRecord(isString)({ a: "foo", b: 42 }));
+  await t.step("base guard rejects non-objects", () => {
+    assertFalse(isRecord(null));
+    assertFalse(isRecord([1, 2, 3]));
+    assertFalse(isRecord("not object"));
+    assertFalse(isRecord(42));
   });
 
-  await t.step("accepts record with number values", () => {
-    assert(isRecord(isNumber)({ x: 1, y: 2 }));
+  await t.step(".of() accepts record with matching values", () => {
+    assert(isRecord.of(isString)({ a: "foo", b: "bar" }));
   });
 
-  await t.step("accepts empty object", () => {
-    assert(isRecord(isString)({}));
+  await t.step(".of() rejects record with non-matching values", () => {
+    assertFalse(isRecord.of(isString)({ a: "foo", b: 42 }));
   });
 
-  await t.step("rejects null", () => {
-    assertFalse(isRecord(isString)(null));
+  await t.step(".of() accepts record with number values", () => {
+    assert(isRecord.of(isNumber)({ x: 1, y: 2 }));
   });
 
-  await t.step("rejects array", () => {
-    assertFalse(isRecord(isString)([1, 2, 3]));
+  await t.step(".of() accepts empty object", () => {
+    assert(isRecord.of(isString)({}));
   });
 
-  await t.step("rejects non-object", () => {
-    assertFalse(isRecord(isString)("not object"));
+  await t.step(".of() rejects null", () => {
+    assertFalse(isRecord.of(isString)(null));
   });
 
-  await t.step("validate returns issues with path", () => {
-    const result = isRecord(isString).validate({ a: "ok", b: 42 });
+  await t.step(".of() rejects array", () => {
+    assertFalse(isRecord.of(isString)([1, 2, 3]));
+  });
+
+  await t.step(".of() validate returns issues with path", () => {
+    const result = isRecord.of(isString).validate({ a: "ok", b: 42 });
     assert("issues" in result);
     if ("issues" in result) {
       assert(result.issues!.length > 0);
@@ -5689,26 +5697,26 @@ Deno.test("isRecord", async (t) => {
     }
   });
 
-  await t.step("strict throws on invalid value", () => {
-    assertThrows(() => isRecord(isString).strict({ a: 42 }));
+  await t.step(".of() strict throws on invalid value", () => {
+    assertThrows(() => isRecord.of(isString).strict({ a: 42 }));
   });
 
-  await t.step("optional accepts undefined", () => {
-    assert(isRecord(isString).optional(undefined));
+  await t.step(".of() optional accepts undefined", () => {
+    assert(isRecord.of(isString).optional(undefined));
   });
 
-  await t.step("works inside a shape", () => {
-    const isConfig = createTypeGuard({ env: isRecord(isString) });
+  await t.step(".of() works inside a shape", () => {
+    const isConfig = createTypeGuard({ env: isRecord.of(isString) });
     assert(isConfig({ env: { NODE_ENV: "prod" } }));
     assertFalse(isConfig({ env: { NODE_ENV: 123 } }));
   });
 
-  await t.step("two-arg form validates keys", () => {
+  await t.step(".of() two-arg form validates keys", () => {
     const isEnvKey = createTypeGuard<"NODE_ENV" | "PORT">("EnvKey", (v) => {
       if (v === "NODE_ENV" || v === "PORT") return v;
       return null;
     });
-    const guard = isRecord(isEnvKey, isString);
+    const guard = isRecord.of(isEnvKey, isString);
     assert(guard({ NODE_ENV: "prod", PORT: "3000" }));
     assertFalse(guard({ INVALID_KEY: "value" }));
   });

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -150,7 +150,7 @@ function isTypeGuardShape(value: unknown): value is TypeGuardShape {
     typeof value !== "function";
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
@@ -282,7 +282,7 @@ function validateCompiledShapeBoolean(
   value: unknown,
   fields: FieldDescriptor[],
 ): boolean {
-  if (!isRecord(value)) return false;
+  if (!isPlainRecord(value)) return false;
 
   for (let i = 0; i < fields.length; i++) {
     const desc = fields[i];
@@ -316,7 +316,7 @@ function validateCompiledShape(
   fields: FieldDescriptor[],
   ctx?: Context,
 ): StandardSchemaV1.Result<Record<string, unknown>> {
-  if (!isRecord(value)) {
+  if (!isPlainRecord(value)) {
     const message = "Expected an object";
 
     if (!ctx) return { issues: [{ message }] };
@@ -1267,5 +1267,70 @@ isTupleOptional.assert = isTupleOptional.strict;
  * @returns true if the value is undefined or a tuple of the specified length, otherwise false
  */
 isTuple.optional = isTupleOptional;
+
+/**
+ * Creates a type guard for `Record<K, V>` dictionaries.
+ *
+ * When called with one argument, validates that all values match the given guard
+ * (keys are any string). When called with two arguments, validates both keys and values.
+ *
+ * @example
+ * ```typescript
+ * const isStringRecord = isRecord(isString);
+ * isStringRecord({ a: "foo", b: "bar" }); // true
+ * isStringRecord({ a: "foo", b: 42 });    // false
+ * isStringRecord({});                     // true (empty is valid)
+ * ```
+ */
+export function isRecord<V>(valueGuard: TypeGuard<V>): TypeGuard<Record<string, V>>;
+export function isRecord<K extends string, V>(
+  keyGuard: TypeGuard<K>,
+  valueGuard: TypeGuard<V>,
+): TypeGuard<Record<K, V>>;
+export function isRecord<V>(
+  keyOrValueGuard: TypeGuard<unknown>,
+  valueGuard?: TypeGuard<unknown>,
+): TypeGuard<Record<string, V>> {
+  // Resolve overloads
+  const kGuard = valueGuard ? keyOrValueGuard : undefined;
+  const vGuard = valueGuard ?? keyOrValueGuard;
+
+  // Build name
+  const kName = kGuard && hasName(kGuard) ? kGuard._.name : "string";
+  const vName = hasName(vGuard as TypeGuard<unknown>)
+    ? (vGuard as TypeGuard<unknown>)._.name
+    : "unknown";
+  const name = `Record<${kName}, ${vName}>`;
+
+  return createTypeGuard(name, (val, helpers) => {
+    if (!isObject(val) || Array.isArray(val)) return null;
+
+    const ctx = (helpers as HelpersWithContext)._ctx;
+    const entries = Object.entries(val as Record<string, unknown>);
+
+    for (const [key, value] of entries) {
+      // Validate key if key guard provided
+      if (kGuard && !kGuard(key)) {
+        if (ctx) ctx.addIssue(`Invalid key "${key}" in ${name}`);
+        return null;
+      }
+
+      // Validate value
+      if (ctx) {
+        ctx.pushPath(key);
+        try {
+          const result = (vGuard as TypeGuard<unknown>)._.context(value, ctx);
+          if (!("value" in result)) return null;
+        } finally {
+          ctx.popPath();
+        }
+      } else {
+        if (!(vGuard as TypeGuard<unknown>)(value)) return null;
+      }
+    }
+
+    return val as Record<string, V>;
+  });
+}
 
 export { isEmpty, isIterable, isNil, isNull, isTuple };

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -19,6 +19,7 @@ import type {
   NamedParser,
   NumberTypeGuard,
   Parser,
+  RecordTypeGuard,
   ParserEntry,
   Predicate,
   StrictTypeGuard,
@@ -150,7 +151,7 @@ function isTypeGuardShape(value: unknown): value is TypeGuardShape {
     typeof value !== "function";
 }
 
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
+function _isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
@@ -282,7 +283,7 @@ function validateCompiledShapeBoolean(
   value: unknown,
   fields: FieldDescriptor[],
 ): boolean {
-  if (!isPlainRecord(value)) return false;
+  if (!_isRecord(value)) return false;
 
   for (let i = 0; i < fields.length; i++) {
     const desc = fields[i];
@@ -316,7 +317,7 @@ function validateCompiledShape(
   fields: FieldDescriptor[],
   ctx?: Context,
 ): StandardSchemaV1.Result<Record<string, unknown>> {
-  if (!isPlainRecord(value)) {
+  if (!_isRecord(value)) {
     const message = "Expected an object";
 
     if (!ctx) return { issues: [{ message }] };
@@ -1269,68 +1270,71 @@ isTupleOptional.assert = isTupleOptional.strict;
 isTuple.optional = isTupleOptional;
 
 /**
- * Creates a type guard for `Record<K, V>` dictionaries.
- *
- * When called with one argument, validates that all values match the given guard
- * (keys are any string). When called with two arguments, validates both keys and values.
+ * Returns true if input is a plain object (not null, not an array).
+ * Use `.of(guard)` to validate that all values match a specific type.
  *
  * @example
  * ```typescript
- * const isStringRecord = isRecord(isString);
+ * isRecord({ a: 1, b: 2 });              // true
+ * isRecord([1, 2]);                      // false
+ * isRecord(null);                        // false
+ *
+ * const isStringRecord = isRecord.of(isString);
  * isStringRecord({ a: "foo", b: "bar" }); // true
  * isStringRecord({ a: "foo", b: 42 });    // false
- * isStringRecord({});                     // true (empty is valid)
  * ```
  */
-export function isRecord<V>(valueGuard: TypeGuard<V>): TypeGuard<Record<string, V>>;
-export function isRecord<K extends string, V>(
-  keyGuard: TypeGuard<K>,
-  valueGuard: TypeGuard<V>,
-): TypeGuard<Record<K, V>>;
-export function isRecord<V>(
-  keyOrValueGuard: TypeGuard<unknown>,
-  valueGuard?: TypeGuard<unknown>,
-): TypeGuard<Record<string, V>> {
-  // Resolve overloads
-  const kGuard = valueGuard ? keyOrValueGuard : undefined;
-  const vGuard = valueGuard ?? keyOrValueGuard;
+export const isRecord: RecordTypeGuard = Object.assign(
+  createTypeGuard(
+    "record",
+    (t): Record<string, unknown> | null =>
+      typeof t === "object" && t !== null && !Array.isArray(t)
+        ? t as Record<string, unknown>
+        : null,
+  ),
+  {
+    of: (<V>(
+      keyOrValueGuard: TypeGuard<unknown>,
+      valueGuard?: TypeGuard<unknown>,
+    ) => {
+      const kGuard = valueGuard ? keyOrValueGuard : undefined;
+      const vGuard = valueGuard ?? keyOrValueGuard;
 
-  // Build name
-  const kName = kGuard && hasName(kGuard) ? kGuard._.name : "string";
-  const vName = hasName(vGuard as TypeGuard<unknown>)
-    ? (vGuard as TypeGuard<unknown>)._.name
-    : "unknown";
-  const name = `Record<${kName}, ${vName}>`;
+      const kName = kGuard && hasName(kGuard) ? kGuard._.name : "string";
+      const vName = hasName(vGuard as TypeGuard<unknown>)
+        ? (vGuard as TypeGuard<unknown>)._.name
+        : "unknown";
+      const name = `Record<${kName}, ${vName}>`;
 
-  return createTypeGuard(name, (val, helpers) => {
-    if (!isObject(val) || Array.isArray(val)) return null;
+      return createTypeGuard(name, (val, helpers) => {
+        if (!isObject(val) || Array.isArray(val)) return null;
 
-    const ctx = (helpers as HelpersWithContext)._ctx;
-    const entries = Object.entries(val as Record<string, unknown>);
+        const ctx = (helpers as HelpersWithContext)._ctx;
+        const entries = Object.entries(val as Record<string, unknown>);
 
-    for (const [key, value] of entries) {
-      // Validate key if key guard provided
-      if (kGuard && !kGuard(key)) {
-        if (ctx) ctx.addIssue(`Invalid key "${key}" in ${name}`);
-        return null;
-      }
+        for (const [key, value] of entries) {
+          if (kGuard && !kGuard(key)) {
+            if (ctx) ctx.addIssue(`Invalid key "${key}" in ${name}`);
+            return null;
+          }
 
-      // Validate value
-      if (ctx) {
-        ctx.pushPath(key);
-        try {
-          const result = (vGuard as TypeGuard<unknown>)._.context(value, ctx);
-          if (!("value" in result)) return null;
-        } finally {
-          ctx.popPath();
+          if (ctx) {
+            ctx.pushPath(key);
+            try {
+              const result = (vGuard as TypeGuard<unknown>)._.context(value, ctx);
+              if (!("value" in result)) return null;
+            } finally {
+              ctx.popPath();
+            }
+          } else {
+            if (!(vGuard as TypeGuard<unknown>)(value)) return null;
+          }
         }
-      } else {
-        if (!(vGuard as TypeGuard<unknown>)(value)) return null;
-      }
-    }
 
-    return val as Record<string, V>;
-  });
-}
+        return val as Record<string, V>;
+      });
+    }) as RecordTypeGuard["of"],
+  },
+) as RecordTypeGuard;
 
 export { isEmpty, isIterable, isNil, isNull, isTuple };

--- a/packages/guardis/src/types.ts
+++ b/packages/guardis/src/types.ts
@@ -355,6 +355,17 @@ export interface ArrayTypeGuard<T = unknown> extends TypeGuard<T[]> {
   range(min: number, max: number): ArrayTypeGuard<T>;
 }
 
+/** A record type guard with `.of()` for typed value/key validation */
+export interface RecordTypeGuard extends TypeGuard<Record<string, unknown>> {
+  /** Returns a guard that validates all values match the given guard */
+  of<V>(valueGuard: TypeGuard<V>): TypeGuard<Record<string, V>>;
+  /** Returns a guard that validates both keys and values */
+  of<K extends string, V>(
+    keyGuard: TypeGuard<K>,
+    valueGuard: TypeGuard<V>,
+  ): TypeGuard<Record<K, V>>;
+}
+
 /** An optional type guard that accepts undefined in addition to the base type */
 export interface OptionalTypeGuard<T1> {
   /** Internal metadata with optional flag for shape type inference */


### PR DESCRIPTION
## Summary
- Add `isRecord(valueGuard)` and `isRecord(keyGuard, valueGuard)` factory functions for validating `Record<K, V>` dictionaries
- Supports context-aware validation with path tracking for `.validate()` and `.strict()` 
- Works composably inside shapes, with `.optional`, `.or`, etc.

Closes #70

## Test plan
- [x] Accepts records with matching values (`isRecord(isString)`)
- [x] Rejects records with non-matching values
- [x] Accepts empty objects
- [x] Rejects null, arrays, and non-objects
- [x] `.validate()` returns issues with correct path info
- [x] `.strict()` throws on invalid input
- [x] `.optional` accepts undefined
- [x] Works inside `createTypeGuard` shapes
- [x] Two-arg form validates keys
- [x] All 199 existing tests still pass