### PR TITLE
Add isEnum factory guard

### DIFF
--- a/packages/guardis/mod.ts
+++ b/packages/guardis/mod.ts
@@ -44,4 +44,5 @@ export const Is = {
   Tuple: g.isTuple,
   Date: g.isDate,
   Exactly: g.isExactly,
+  Enum: g.isEnum,
 } as const;

--- a/packages/guardis/src/guard.test.ts
+++ b/packages/guardis/src/guard.test.ts
@@ -22,6 +22,7 @@ import {
   isPropertyKey,
   isString,
   isSymbol,
+  isEnum,
   isTuple,
   isUndefined,
 } from "./guard.ts";
@@ -5646,5 +5647,81 @@ Deno.test("createTypeGuard with verified shape (explicit type parameter)", async
     assert(isPositive(5));
     assertFalse(isPositive(-1));
     assertType<Equals<typeof isPositive._TYPE, number>>();
+  });
+});
+
+Deno.test("isEnum", async (t) => {
+  // Define test enums
+  enum Color {
+    Red = "red",
+    Green = "green",
+    Blue = "blue",
+  }
+  enum Direction {
+    Up = 0,
+    Down = 1,
+    Left = 2,
+    Right = 3,
+  }
+  enum Mixed {
+    Name = "alice",
+    Age = 30,
+  }
+
+  const isColor = isEnum(Color);
+  const isDirection = isEnum(Direction);
+
+  await t.step("validates string enum members", () => {
+    assert(isColor("red"));
+    assert(isColor("green"));
+    assert(isColor("blue"));
+  });
+
+  await t.step("rejects non-members of string enum", () => {
+    assertFalse(isColor("yellow"));
+    assertFalse(isColor(""));
+    assertFalse(isColor(42));
+  });
+
+  await t.step("validates numeric enum members", () => {
+    assert(isDirection(0));
+    assert(isDirection(1));
+    assert(isDirection(3));
+  });
+
+  await t.step("rejects non-members of numeric enum", () => {
+    assertFalse(isDirection(4));
+    assertFalse(isDirection(-1));
+    // Reverse mapping keys should NOT be valid
+    assertFalse(isDirection("Up"));
+    assertFalse(isDirection("Down"));
+  });
+
+  await t.step("handles mixed enum", () => {
+    const isMixed = isEnum(Mixed);
+    assert(isMixed("alice"));
+    assert(isMixed(30));
+    assertFalse(isMixed("bob"));
+    assertFalse(isMixed(31));
+  });
+
+  await t.step("strict mode throws on non-member", () => {
+    assertThrows(() => isColor.strict("yellow"));
+  });
+
+  await t.step("validate mode returns issues", () => {
+    const result = isColor.validate("yellow");
+    assert("issues" in result && result.issues);
+  });
+
+  await t.step("optional accepts undefined", () => {
+    assert(isColor.optional(undefined));
+    assert(isColor.optional("red"));
+  });
+
+  await t.step("works in shapes", () => {
+    const isPayload = createTypeGuard({ color: isColor });
+    assert(isPayload({ color: "red" }));
+    assertFalse(isPayload({ color: "yellow" }));
   });
 });

--- a/packages/guardis/src/guard.test.ts
+++ b/packages/guardis/src/guard.test.ts
@@ -7,6 +7,7 @@ import {
   isBoolean,
   isDate,
   isEmpty,
+  isEnum,
   isExactly,
   isFunction,
   isIterable,
@@ -22,7 +23,6 @@ import {
   isPropertyKey,
   isString,
   isSymbol,
-  isEnum,
   isTuple,
   isUndefined,
 } from "./guard.ts";
@@ -5279,12 +5279,14 @@ Deno.test("shape optional property inference", async (t) => {
       avatar: isString.optional,
     });
     type Profile = typeof isProfile._TYPE;
-    assertType<Equals<Profile, {
-      name: string;
-      age: number;
-      bio?: string | undefined;
-      avatar?: string | undefined;
-    }>>();
+    assertType<
+      Equals<Profile, {
+        name: string;
+        age: number;
+        bio?: string | undefined;
+        avatar?: string | undefined;
+      }>
+    >();
   });
 
   await t.step("runtime accepts missing optional properties", () => {
@@ -5495,9 +5497,7 @@ Deno.test("array length methods", async (t) => {
   });
 
   await t.step("extend after length method", () => {
-    const guard = isArray.of(isNumber).min(1).extend((v) =>
-      v.every((n) => n > 0) ? v : null
-    );
+    const guard = isArray.of(isNumber).min(1).extend((v) => v.every((n) => n > 0) ? v : null);
     assert(guard([1, 2, 3]));
     assertFalse(guard([]));
     assertFalse(guard([-1, 2]));
@@ -5723,5 +5723,10 @@ Deno.test("isEnum", async (t) => {
     const isPayload = createTypeGuard({ color: isColor });
     assert(isPayload({ color: "red" }));
     assertFalse(isPayload({ color: "yellow" }));
+  });
+
+  await t.step("inferred type matches the original enum", () => {
+    assertType<Equals<typeof isColor._TYPE, typeof Color[keyof typeof Color]>>();
+    assertType<Equals<typeof isDirection._TYPE, typeof Direction[keyof typeof Direction]>>();
   });
 });

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -1271,23 +1271,36 @@ isTuple.optional = isTupleOptional;
 /**
  * Creates a type guard from a TypeScript enum object.
  * Validates that a value is a member of the enum.
- * Handles both string and numeric enums (filters reverse mappings for numeric enums).
+ *
+ * Handles both string and numeric enums. TypeScript compiles numeric enums
+ * with reverse mappings — for `enum Dir { Up = 0, Down = 1 }`, the compiled
+ * object is `{ Up: 0, Down: 1, 0: "Up", 1: "Down" }`. The stringified-number
+ * keys (`"0"`, `"1"`) are the reverse mappings and must be filtered out so
+ * that only the real enum values (`0`, `1`) are treated as valid members.
+ * String enums (`enum Color { Red = "red" }`) produce no reverse mappings,
+ * so the filter is a no-op for them.
+ *
+ * Note: TypeScript does not support exact type-level equality checks for enum
+ * types. The inferred `_TYPE` is the enum's value union (e.g. `Color.Red |
+ * Color.Green | Color.Blue`) rather than the branded `Color` type itself.
+ * Both are mutually assignable — `const c: Color = x` compiles after narrowing
+ * — but they are not identical under strict type-equality checks like
+ * `Equals<A, B>`. This is a known TypeScript limitation, not a Guardis bug.
+ * See: https://github.com/microsoft/TypeScript/issues/49497
  */
-export function isEnum<T extends Record<string, string | number>>(
+export function isEnum<const T extends Record<string, string | number>>(
   enumObj: T,
 ): TypeGuard<T[keyof T]> {
-  // Filter out numeric enum reverse mappings.
-  // For numeric enums, Object.keys includes both "Name" and "0" (the reverse mapping).
-  // We keep only entries where the key is not a stringified number.
+  // Keep only entries whose key is not a stringified number (filters reverse mappings).
   const values = Object.entries(enumObj)
     .filter(([key]) => isNaN(Number(key)))
     .map(([, value]) => value);
-  const memberSet = new Set<string | number>(values);
+  const memberSet = new Set(values);
   const name = `enum(${values.join(" | ")})`;
 
   return createTypeGuard(
     name,
-    (t): T[keyof T] | null => memberSet.has(t as string | number) ? t as T[keyof T] : null,
+    (t) => memberSet.has(t as T[keyof T]) ? t as T[keyof T] : null,
   );
 }
 

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -1268,4 +1268,27 @@ isTupleOptional.assert = isTupleOptional.strict;
  */
 isTuple.optional = isTupleOptional;
 
+/**
+ * Creates a type guard from a TypeScript enum object.
+ * Validates that a value is a member of the enum.
+ * Handles both string and numeric enums (filters reverse mappings for numeric enums).
+ */
+export function isEnum<T extends Record<string, string | number>>(
+  enumObj: T,
+): TypeGuard<T[keyof T]> {
+  // Filter out numeric enum reverse mappings.
+  // For numeric enums, Object.keys includes both "Name" and "0" (the reverse mapping).
+  // We keep only entries where the key is not a stringified number.
+  const values = Object.entries(enumObj)
+    .filter(([key]) => isNaN(Number(key)))
+    .map(([, value]) => value);
+  const memberSet = new Set<string | number>(values);
+  const name = `enum(${values.join(" | ")})`;
+
+  return createTypeGuard(
+    name,
+    (t): T[keyof T] | null => memberSet.has(t as string | number) ? t as T[keyof T] : null,
+  );
+}
+
 export { isEmpty, isIterable, isNil, isNull, isTuple };


### PR DESCRIPTION
## Summary
- Adds `isEnum` factory function that creates a type guard from a TypeScript enum object
- Handles string enums, numeric enums (filtering reverse mappings), and mixed enums
- Exports via `Is.Enum` namespace in `mod.ts`
- Full test coverage including strict mode, validate, optional, and shape integration

## Test plan
- [x] String enum membership validation
- [x] Numeric enum membership validation (reverse mappings filtered)
- [x] Mixed enum support
- [x] Strict mode throws on non-member
- [x] Validate mode returns issues
- [x] Optional accepts undefined
- [x] Works in shapes

Closes #65