### PR TITLE
Auto-compile parser guards for fast-fail parity with shape

### DIFF
--- a/packages/guardis/benchmarks/parser-vs-shape.bench.ts
+++ b/packages/guardis/benchmarks/parser-vs-shape.bench.ts
@@ -1,0 +1,402 @@
+import {
+  createTypeGuard,
+  isArray,
+  isBoolean,
+  isNumber,
+  isObject,
+  isString,
+} from "../src/guard.ts";
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+// --- Flat (5 fields) -------------------------------------------------------
+
+const FLAT_VALID = {
+  name: "Alice",
+  age: 30,
+  active: true,
+  score: 95.5,
+  email: "alice@example.com",
+};
+
+const FLAT_INVALID = {
+  name: 123,
+  age: "thirty",
+  active: "yes",
+  score: null,
+  email: 42,
+};
+
+// --- Nested (3 levels, 14 fields) ------------------------------------------
+
+const NESTED_VALID = {
+  user: {
+    name: "Alice",
+    email: "alice@example.com",
+    age: 30,
+    active: true,
+  },
+  address: {
+    street: "123 Main St",
+    city: "Springfield",
+    state: "IL",
+    zip: "62701",
+  },
+  tags: ["admin", "verified"],
+  metadata: {
+    source: "web",
+    version: 2,
+    referral: "campaign-123",
+  },
+};
+
+const NESTED_INVALID = {
+  user: { name: 42, email: true, age: "old", active: "yes" },
+  address: { street: 100, city: null, state: 5, zip: false },
+  tags: "not-an-array",
+  metadata: { source: 999, version: "two", referral: null },
+};
+
+// --- Deep (5 levels, 26 fields) --------------------------------------------
+
+const DEEP_VALID = {
+  id: 1,
+  name: "Acme Corp",
+  active: true,
+  config: {
+    theme: "dark",
+    version: 3,
+    features: {
+      dashboard: true,
+      analytics: true,
+      notifications: {
+        email: true,
+        sms: false,
+        push: {
+          enabled: true,
+          provider: "firebase",
+          retries: 3,
+        },
+      },
+    },
+  },
+  tags: ["enterprise", "premium"],
+  contacts: {
+    primary: {
+      name: "Bob",
+      email: "bob@acme.com",
+      phone: "555-1234",
+    },
+    billing: {
+      name: "Carol",
+      email: "carol@acme.com",
+      phone: "555-5678",
+    },
+  },
+};
+
+const DEEP_INVALID = {
+  id: "not-a-number",
+  name: 42,
+  active: "yes",
+  config: {
+    theme: 123,
+    version: "three",
+    features: {
+      dashboard: "yes",
+      analytics: 1,
+      notifications: {
+        email: "yes",
+        sms: 0,
+        push: {
+          enabled: "true",
+          provider: 999,
+          retries: "three",
+        },
+      },
+    },
+  },
+  tags: "not-an-array",
+  contacts: {
+    primary: { name: 1, email: false, phone: 0 },
+    billing: { name: 2, email: null, phone: true },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Parser guards
+// ---------------------------------------------------------------------------
+
+type Flat = { name: string; age: number; active: boolean; score: number; email: string };
+
+const flatParser = createTypeGuard<Flat>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "name", isString) &&
+    has(v, "age", isNumber) &&
+    has(v, "active", isBoolean) &&
+    has(v, "score", isNumber) &&
+    has(v, "email", isString)
+  ) return v;
+  return null;
+});
+
+type User = { name: string; email: string; age: number; active: boolean };
+type Address = { street: string; city: string; state: string; zip: string };
+type Metadata = { source: string; version: number; referral: string };
+type Nested = { user: User; address: Address; tags: string[]; metadata: Metadata };
+
+const nestedUserParser = createTypeGuard<User>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "name", isString) &&
+    has(v, "email", isString) &&
+    has(v, "age", isNumber) &&
+    has(v, "active", isBoolean)
+  ) return v;
+  return null;
+});
+
+const nestedAddressParser = createTypeGuard<Address>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "street", isString) &&
+    has(v, "city", isString) &&
+    has(v, "state", isString) &&
+    has(v, "zip", isString)
+  ) return v;
+  return null;
+});
+
+const nestedMetadataParser = createTypeGuard<Metadata>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "source", isString) &&
+    has(v, "version", isNumber) &&
+    has(v, "referral", isString)
+  ) return v;
+  return null;
+});
+
+const nestedParser = createTypeGuard<Nested>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "user", nestedUserParser) &&
+    has(v, "address", nestedAddressParser) &&
+    has(v, "tags", isArray.of(isString)) &&
+    has(v, "metadata", nestedMetadataParser)
+  ) return v;
+  return null;
+});
+
+type Push = { enabled: boolean; provider: string; retries: number };
+type Notifications = { email: boolean; sms: boolean; push: Push };
+type Features = { dashboard: boolean; analytics: boolean; notifications: Notifications };
+type Config = { theme: string; version: number; features: Features };
+type Contact = { name: string; email: string; phone: string };
+type Contacts = { primary: Contact; billing: Contact };
+type Deep = {
+  id: number;
+  name: string;
+  active: boolean;
+  config: Config;
+  tags: string[];
+  contacts: Contacts;
+};
+
+const deepPushParser = createTypeGuard<Push>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "enabled", isBoolean) &&
+    has(v, "provider", isString) &&
+    has(v, "retries", isNumber)
+  ) return v;
+  return null;
+});
+
+const deepNotificationsParser = createTypeGuard<Notifications>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "email", isBoolean) &&
+    has(v, "sms", isBoolean) &&
+    has(v, "push", deepPushParser)
+  ) return v;
+  return null;
+});
+
+const deepFeaturesParser = createTypeGuard<Features>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "dashboard", isBoolean) &&
+    has(v, "analytics", isBoolean) &&
+    has(v, "notifications", deepNotificationsParser)
+  ) return v;
+  return null;
+});
+
+const deepConfigParser = createTypeGuard<Config>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "theme", isString) &&
+    has(v, "version", isNumber) &&
+    has(v, "features", deepFeaturesParser)
+  ) return v;
+  return null;
+});
+
+const deepContactParser = createTypeGuard<Contact>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "name", isString) &&
+    has(v, "email", isString) &&
+    has(v, "phone", isString)
+  ) return v;
+  return null;
+});
+
+const deepContactsParser = createTypeGuard<Contacts>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "primary", deepContactParser) &&
+    has(v, "billing", deepContactParser)
+  ) return v;
+  return null;
+});
+
+const deepParser = createTypeGuard<Deep>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "id", isNumber) &&
+    has(v, "name", isString) &&
+    has(v, "active", isBoolean) &&
+    has(v, "config", deepConfigParser) &&
+    has(v, "tags", isArray.of(isString)) &&
+    has(v, "contacts", deepContactsParser)
+  ) return v;
+  return null;
+});
+
+// ---------------------------------------------------------------------------
+// Shape guards
+// ---------------------------------------------------------------------------
+
+const flatShape = createTypeGuard({
+  name: isString,
+  age: isNumber,
+  active: isBoolean,
+  score: isNumber,
+  email: isString,
+});
+
+const nestedShape = createTypeGuard({
+  user: {
+    name: isString,
+    email: isString,
+    age: isNumber,
+    active: isBoolean,
+  },
+  address: {
+    street: isString,
+    city: isString,
+    state: isString,
+    zip: isString,
+  },
+  tags: isArray.of(isString),
+  metadata: {
+    source: isString,
+    version: isNumber,
+    referral: isString,
+  },
+});
+
+const deepShape = createTypeGuard({
+  id: isNumber,
+  name: isString,
+  active: isBoolean,
+  config: {
+    theme: isString,
+    version: isNumber,
+    features: {
+      dashboard: isBoolean,
+      analytics: isBoolean,
+      notifications: {
+        email: isBoolean,
+        sms: isBoolean,
+        push: {
+          enabled: isBoolean,
+          provider: isString,
+          retries: isNumber,
+        },
+      },
+    },
+  },
+  tags: isArray.of(isString),
+  contacts: {
+    primary: {
+      name: isString,
+      email: isString,
+      phone: isString,
+    },
+    billing: {
+      name: isString,
+      email: isString,
+      phone: isString,
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Flat — fast-fail (boolean)
+// ---------------------------------------------------------------------------
+
+Deno.bench({ name: "flat | parser  | valid   | fast-fail", group: "flat-valid",   fn() { flatParser(FLAT_VALID); } });
+Deno.bench({ name: "flat | shape   | valid   | fast-fail", group: "flat-valid",   fn() { flatShape(FLAT_VALID); } });
+Deno.bench({ name: "flat | parser  | invalid | fast-fail", group: "flat-invalid", fn() { flatParser(FLAT_INVALID); } });
+Deno.bench({ name: "flat | shape   | invalid | fast-fail", group: "flat-invalid", fn() { flatShape(FLAT_INVALID); } });
+
+// ---------------------------------------------------------------------------
+// Flat — validate (StandardSchema result)
+// ---------------------------------------------------------------------------
+
+Deno.bench({ name: "flat | parser  | valid   | validate",  group: "flat-valid-v",   fn() { flatParser.validate(FLAT_VALID); } });
+Deno.bench({ name: "flat | shape   | valid   | validate",  group: "flat-valid-v",   fn() { flatShape.validate(FLAT_VALID); } });
+Deno.bench({ name: "flat | parser  | invalid | validate",  group: "flat-invalid-v", fn() { flatParser.validate(FLAT_INVALID); } });
+Deno.bench({ name: "flat | shape   | invalid | validate",  group: "flat-invalid-v", fn() { flatShape.validate(FLAT_INVALID); } });
+
+// ---------------------------------------------------------------------------
+// Nested — fast-fail (boolean)
+// ---------------------------------------------------------------------------
+
+Deno.bench({ name: "nested | parser  | valid   | fast-fail", group: "nested-valid",   fn() { nestedParser(NESTED_VALID); } });
+Deno.bench({ name: "nested | shape   | valid   | fast-fail", group: "nested-valid",   fn() { nestedShape(NESTED_VALID); } });
+Deno.bench({ name: "nested | parser  | invalid | fast-fail", group: "nested-invalid", fn() { nestedParser(NESTED_INVALID); } });
+Deno.bench({ name: "nested | shape   | invalid | fast-fail", group: "nested-invalid", fn() { nestedShape(NESTED_INVALID); } });
+
+// ---------------------------------------------------------------------------
+// Nested — validate (StandardSchema result)
+// ---------------------------------------------------------------------------
+
+Deno.bench({ name: "nested | parser  | valid   | validate",  group: "nested-valid-v",   fn() { nestedParser.validate(NESTED_VALID); } });
+Deno.bench({ name: "nested | shape   | valid   | validate",  group: "nested-valid-v",   fn() { nestedShape.validate(NESTED_VALID); } });
+Deno.bench({ name: "nested | parser  | invalid | validate",  group: "nested-invalid-v", fn() { nestedParser.validate(NESTED_INVALID); } });
+Deno.bench({ name: "nested | shape   | invalid | validate",  group: "nested-invalid-v", fn() { nestedShape.validate(NESTED_INVALID); } });
+
+// ---------------------------------------------------------------------------
+// Deep — fast-fail (boolean)
+// ---------------------------------------------------------------------------
+
+Deno.bench({ name: "deep | parser  | valid   | fast-fail", group: "deep-valid",   fn() { deepParser(DEEP_VALID); } });
+Deno.bench({ name: "deep | shape   | valid   | fast-fail", group: "deep-valid",   fn() { deepShape(DEEP_VALID); } });
+Deno.bench({ name: "deep | parser  | invalid | fast-fail", group: "deep-invalid", fn() { deepParser(DEEP_INVALID); } });
+Deno.bench({ name: "deep | shape   | invalid | fast-fail", group: "deep-invalid", fn() { deepShape(DEEP_INVALID); } });
+
+// ---------------------------------------------------------------------------
+// Deep — validate (StandardSchema result)
+// ---------------------------------------------------------------------------
+
+Deno.bench({ name: "deep | parser  | valid   | validate",  group: "deep-valid-v",   fn() { deepParser.validate(DEEP_VALID); } });
+Deno.bench({ name: "deep | shape   | valid   | validate",  group: "deep-valid-v",   fn() { deepShape.validate(DEEP_VALID); } });
+Deno.bench({ name: "deep | parser  | invalid | validate",  group: "deep-invalid-v", fn() { deepParser.validate(DEEP_INVALID); } });
+Deno.bench({ name: "deep | shape   | invalid | validate",  group: "deep-invalid-v", fn() { deepShape.validate(DEEP_INVALID); } });

--- a/packages/guardis/deno.json
+++ b/packages/guardis/deno.json
@@ -16,13 +16,17 @@
       "description": "Run unit tests.",
       "command": "deno test"
     },
-    "bench:all": {
-      "description": "Run all library benchmarks on the typeguards to detect slow parsing logic.",
-      "command": "deno bench benchmarks/guard*.bench.ts"
+    "bench:competitors": {
+      "description": "Run comparative benchmarks against Zod, ArkType, and Valibot.",
+      "command": "deno bench --config ../benchmarks/deno.json ../benchmarks/"
     },
-    "bench:guards": {
-      "description": "Run library benchmarks on the typeguards to detect slow parsing logic.",
-      "command": "deno bench benchmarks/guard.bench.ts"
+    "bench:primitives": {
+      "description": "Benchmark primitive type guards.",
+      "command": "deno bench benchmarks/guard.bench.ts benchmarks/guard.json.bench.ts benchmarks/guard.jsonArray.bench.ts"
+    },
+    "bench:parser-vs-shape": {
+      "description": "Benchmark parser vs shape object validation across complexity levels.",
+      "command": "deno bench benchmarks/parser-vs-shape.bench.ts"
     },
     "build:npm": {
       "description": "Build npm package using dnt.",

--- a/packages/guardis/src/guard.test.ts
+++ b/packages/guardis/src/guard.test.ts
@@ -5648,3 +5648,161 @@ Deno.test("createTypeGuard with verified shape (explicit type parameter)", async
     assertType<Equals<typeof isPositive._TYPE, number>>();
   });
 });
+
+Deno.test("Parser auto-compilation safety", async (t) => {
+  await t.step("parser with data-dependent property access is not broken by compilation", () => {
+    // This parser accesses v.age directly after has() — the Proxy get trap
+    // must cause compilation bailout so the custom logic is preserved.
+    type Person = { name: string; age: number };
+    const isAdult = createTypeGuard<Person>((v, { has }) => {
+      if (isObject(v) && has(v, "name", isString) && has(v, "age", isNumber)) {
+        if (v.age < 18) return null;
+        return v;
+      }
+      return null;
+    });
+
+    assert(isAdult({ name: "Alice", age: 30 }));
+    assertFalse(isAdult({ name: "Bob", age: 10 }));
+    assertFalse(isAdult({ name: "Charlie" }));
+    assertFalse(isAdult("not an object"));
+  });
+
+  await t.step("parser with Object.keys enumeration is not broken by compilation", () => {
+    // Object.keys triggers ownKeys trap — must bail out.
+    const isStrictObject = createTypeGuard<{ name: string }>((v, { has }) => {
+      if (isObject(v) && has(v, "name", isString)) {
+        if (Object.keys(v).length > 1) return null;
+        return v;
+      }
+      return null;
+    });
+
+    assert(isStrictObject({ name: "Alice" }));
+    assertFalse(isStrictObject({ name: "Alice", extra: true }));
+  });
+
+  await t.step("parser that transforms the value is not broken by compilation", () => {
+    const isNormalized = createTypeGuard<{ name: string; normalized: true }>((v, { has }) => {
+      if (isObject(v) && has(v, "name", isString)) {
+        return { ...v, normalized: true as const };
+      }
+      return null;
+    });
+
+    const result = isNormalized({ name: "Alice" });
+    assert(result);
+    // Validate the transform actually happened
+    const validated = isNormalized.validate({ name: "Alice" });
+    assert("value" in validated);
+    assertEquals(validated.value.normalized, true);
+  });
+
+  await t.step("parser using fail helper is not broken by compilation", () => {
+    const isPositiveAge = createTypeGuard<number>("PositiveAge", (v, { fail }) => {
+      if (typeof v !== "number") return fail("Must be a number");
+      if (v < 0) return fail("Must be positive");
+      return v;
+    });
+
+    assert(isPositiveAge(5));
+    assertFalse(isPositiveAge(-1));
+    assertFalse(isPositiveAge("not a number"));
+  });
+
+  await t.step("parser using includes helper is not broken by compilation", () => {
+    const VALID_ROLES = ["admin", "user", "guest"] as const;
+    const isRole = createTypeGuard<{ role: string }>((v, { has, includes }) => {
+      if (isObject(v) && has(v, "role", isString) && includes(VALID_ROLES, v.role)) {
+        return v;
+      }
+      return null;
+    });
+
+    assert(isRole({ role: "admin" }));
+    assertFalse(isRole({ role: "superadmin" }));
+  });
+
+  await t.step("compilable parser achieves same results as shape", () => {
+    // A standard has-chain parser — should be auto-compiled.
+    type User = { name: string; age: number; active: boolean };
+    const isUserParser = createTypeGuard<User>((v, { has }) => {
+      if (
+        isObject(v) &&
+        has(v, "name", isString) &&
+        has(v, "age", isNumber) &&
+        has(v, "active", isBoolean)
+      ) return v;
+      return null;
+    });
+
+    const isUserShape = createTypeGuard({
+      name: isString,
+      age: isNumber,
+      active: isBoolean,
+    });
+
+    const valid = { name: "Alice", age: 30, active: true };
+    const invalid = { name: 123, age: "thirty", active: "yes" };
+
+    // Boolean path: same results
+    assertEquals(isUserParser(valid), isUserShape(valid));
+    assertEquals(isUserParser(invalid), isUserShape(invalid));
+
+    // Missing field
+    assertFalse(isUserParser({ name: "Alice", age: 30 }));
+    assertFalse(isUserShape({ name: "Alice", age: 30 }));
+
+    // Not an object
+    assertFalse(isUserParser("string"));
+    assertFalse(isUserShape("string"));
+    assertFalse(isUserParser(null));
+    assertFalse(isUserShape(null));
+  });
+
+  await t.step("parser with hasOptional compiles and works", () => {
+    type User = { name: string; age?: number };
+    const isUser = createTypeGuard<User>((v, { has, hasOptional }) => {
+      if (isObject(v) && has(v, "name", isString) && hasOptional(v, "age", isNumber)) {
+        return v;
+      }
+      return null;
+    });
+
+    assert(isUser({ name: "Alice" }));
+    assert(isUser({ name: "Alice", age: 30 }));
+    assertFalse(isUser({ name: "Alice", age: "thirty" }));
+    assertFalse(isUser({}));
+  });
+
+  await t.step("parser with hasNot compiles and works", () => {
+    type PublicUser = { name: string };
+    const isPublicUser = createTypeGuard<PublicUser>((v, { has, hasNot }) => {
+      if (isObject(v) && has(v, "name", isString) && hasNot(v, "password")) {
+        return v;
+      }
+      return null;
+    });
+
+    assert(isPublicUser({ name: "Alice" }));
+    assertFalse(isPublicUser({ name: "Alice", password: "secret" }));
+    assertFalse(isPublicUser({}));
+  });
+
+  await t.step("parser with nested guards compiles and works", () => {
+    type Address = { city: string; zip: string };
+    type Person = { name: string; address: Address };
+    const isAddress = createTypeGuard<Address>((v, { has }) => {
+      if (isObject(v) && has(v, "city", isString) && has(v, "zip", isString)) return v;
+      return null;
+    });
+    const isPerson = createTypeGuard<Person>((v, { has }) => {
+      if (isObject(v) && has(v, "name", isString) && has(v, "address", isAddress)) return v;
+      return null;
+    });
+
+    assert(isPerson({ name: "Alice", address: { city: "NYC", zip: "10001" } }));
+    assertFalse(isPerson({ name: "Alice", address: { city: "NYC" } }));
+    assertFalse(isPerson({ name: "Alice" }));
+  });
+});

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -161,7 +161,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 type FieldDescriptor =
   | { kind: "typeGuard"; key: string; guard: TypeGuard<unknown> }
   | { kind: "nested"; key: string; fields: FieldDescriptor[] }
-  | { kind: "typePredicate"; key: string; guard: (value: unknown) => boolean };
+  | { kind: "typePredicate"; key: string; guard: (value: unknown) => boolean }
+  | { kind: "required"; key: string }
+  | { kind: "absent"; key: string };
 
 /**
  * Compiles a TypeGuardShape into a pre-resolved array of field descriptors.
@@ -267,6 +269,30 @@ function validateCompiledField(
         }
         break;
       }
+      case "required": {
+        if (key in obj) {
+          result[key] = obj[key];
+        } else {
+          const message = `Missing required property: ${key}`;
+          if (ctx) {
+            ctx.addIssue(message);
+          } else {
+            localIssues.push({ message, path: [key] });
+          }
+        }
+        break;
+      }
+      case "absent": {
+        if (key in obj) {
+          const message = `Property must not be present: ${key}`;
+          if (ctx) {
+            ctx.addIssue(message);
+          } else {
+            localIssues.push({ message, path: [key] });
+          }
+        }
+        break;
+      }
     }
   } finally {
     if (ctx) ctx.popPath();
@@ -300,6 +326,14 @@ function validateCompiledShapeBoolean(
       }
       case "typePredicate": {
         if (!desc.guard(value[key])) return false;
+        break;
+      }
+      case "required": {
+        if (!(key in value)) return false;
+        break;
+      }
+      case "absent": {
+        if (key in value) return false;
         break;
       }
     }
@@ -517,6 +551,125 @@ const createNotEmptyTypeGuard = <T>(guard: Predicate<T>) => {
  * ```
  */
 
+/**
+ * Classifies a guard into a FieldDescriptor, reusing the same logic as compileShape.
+ */
+function classifyGuard(
+  key: string,
+  guard: ((v: unknown) => boolean) | TypeGuard<unknown>,
+): FieldDescriptor {
+  if (hasContext(guard as Predicate<unknown>)) {
+    return { kind: "typeGuard", key, guard: guard as unknown as TypeGuard<unknown> };
+  }
+  return { kind: "typePredicate", key, guard: guard as (value: unknown) => boolean };
+}
+
+/**
+ * Attempts to auto-compile a parser callback into pre-compiled field descriptors.
+ * Runs the parser once at creation time against a Proxy probe that records
+ * has/hasOptional/hasNot calls. If the parser follows a compilable pattern
+ * (isObject + unconditional has-chain, returning value unchanged), returns
+ * a compiled parser equivalent to shape-based guards. Otherwise returns null
+ * and the caller falls back to the original closure-based parser.
+ */
+function tryCompileParser<T1>(parser: Parser<T1>): Parser<T1> | null {
+  const fields: FieldDescriptor[] = [];
+  let failed = false;
+
+  const probe = new Proxy({} as Record<string, unknown>, {
+    has() {
+      return true;
+    },
+    get() {
+      failed = true;
+      return undefined;
+    },
+    ownKeys() {
+      failed = true;
+      return [];
+    },
+    set() {
+      failed = true;
+      return true;
+    },
+    deleteProperty() {
+      failed = true;
+      return true;
+    },
+  });
+
+  const probeHelpers: HelpersWithContext = {
+    has: ((_t: object, k: PropertyKey, guard?: (v: unknown) => boolean) => {
+      if (failed) return true;
+      if (guard) {
+        fields.push(classifyGuard(String(k), guard));
+      } else {
+        fields.push({ kind: "required", key: String(k) });
+      }
+      return true;
+    }) as HelpersWithContext["has"],
+    hasOptional: ((_t: object, k: PropertyKey, guard?: (v: unknown) => boolean) => {
+      if (failed) return true;
+      if (guard && hasContext(guard as Predicate<unknown>)) {
+        const g = guard as unknown as TypeGuard<unknown>;
+        if (g.optional) {
+          fields.push({ kind: "typeGuard", key: String(k), guard: g.optional as unknown as TypeGuard<unknown> });
+        } else {
+          fields.push(classifyGuard(String(k), guard));
+        }
+      } else if (guard) {
+        fields.push({ kind: "typePredicate", key: String(k), guard: guard as (v: unknown) => boolean });
+      }
+      return true;
+    }) as HelpersWithContext["hasOptional"],
+    hasNot: ((_t: object, k: PropertyKey) => {
+      if (failed) return true;
+      fields.push({ kind: "absent", key: String(k) });
+      return true;
+    }) as HelpersWithContext["hasNot"],
+    tupleHas: (() => {
+      failed = true;
+      return true;
+    }) as unknown as HelpersWithContext["tupleHas"],
+    includes: ((arr: readonly unknown[], val: unknown) => {
+      failed = true;
+      return arr.includes(val);
+    }) as HelpersWithContext["includes"],
+    keyOf: (() => {
+      failed = true;
+      return false;
+    }) as unknown as HelpersWithContext["keyOf"],
+    exact: ((a: unknown, b: unknown) => {
+      failed = true;
+      return a === b;
+    }) as HelpersWithContext["exact"],
+    fail: (() => {
+      failed = true;
+      return null;
+    }) as HelpersWithContext["fail"],
+    _ctx: undefined,
+  };
+
+  try {
+    const result = parser(probe as unknown, probeHelpers);
+    if (result !== probe || failed || fields.length === 0) return null;
+  } catch {
+    return null;
+  }
+
+  // Compilation succeeded — use compiled fields for the boolean fast path,
+  // but fall back to the original parser for the validate path to preserve
+  // exact behavioral parity (original object returned, custom error messages, etc.)
+  return (val: unknown, helpers: HelpersWithContext) => {
+    const ctx = helpers._ctx;
+    if (ctx === undefined) {
+      return validateCompiledShapeBoolean(val, fields) ? (val as T1) : null;
+    }
+    // Validate path: use original parser to preserve exact error messages and return value
+    return parser(val, helpers);
+  };
+}
+
 /** Pre-compiles a shape into a parser that uses cached field descriptors. */
 function compileShapeParser<T1>(shape: TypeGuardShape): Parser<T1> {
   const fields = compileShape(shape);
@@ -615,10 +768,11 @@ export function createTypeGuard<T1>(
   const parserOrShape = args.length === 1 ? args[0] : args[1];
   const name = args.length === 2 ? args[0] as string : undefined;
 
-  // Convert shape to parser, then continue with normal guard creation
+  // Convert shape to parser, or try to auto-compile parser callbacks into
+  // field descriptors for parity with shape-based performance.
   const parser: Parser<T1> = isTypeGuardShape(parserOrShape)
     ? compileShapeParser(parserOrShape)
-    : parserOrShape;
+    : tryCompileParser(parserOrShape) ?? parserOrShape;
 
   /**
    * Internal validation method that accepts a context for path tracking.

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -535,25 +535,6 @@ const createNotEmptyTypeGuard = <T>(guard: Predicate<T>) => {
 };
 
 /**
- * Creates a type guard from a parser function.
- *
- * The parser should perform whatever checks are necessary to safely establish
- * that the input is of the specified type.
- *
- * Injects the `has` utility method as the second argument of any parser, as
- * a convenience to check if a property exists in an object.
- *
- * @param parser A function that returns the value if valid, or null if invalid.
- * @returns A type guard function with utility methods.
- *
- * @example
- * ```typescript
- * const parseString = (val: unknown): string | null => typeof val === 'string' ? val : null;
- * const isString = createTypeGuard(parseString);
- * ```
- */
-
-/**
  * Classifies a guard into a FieldDescriptor, reusing the same logic as compileShape.
  */
 function classifyGuard(
@@ -561,8 +542,9 @@ function classifyGuard(
   guard: ((v: unknown) => boolean) | TypeGuard<unknown>,
 ): FieldDescriptor {
   if (hasContext(guard as Predicate<unknown>)) {
-    return { kind: "typeGuard", key, guard: guard as unknown as TypeGuard<unknown> };
+    return { kind: "typeGuard", key, guard: guard as TypeGuard<unknown> };
   }
+
   return { kind: "typePredicate", key, guard: guard as (value: unknown) => boolean };
 }
 
@@ -603,6 +585,7 @@ function tryCompileParser<T1>(parser: Parser<T1>): Parser<T1> | null {
   const probeHelpers: HelpersWithContext = {
     has: ((_t: object, k: PropertyKey, guard?: (v: unknown) => boolean) => {
       if (failed) return true;
+
       if (guard) {
         fields.push(classifyGuard(String(k), guard));
       } else {
@@ -612,20 +595,26 @@ function tryCompileParser<T1>(parser: Parser<T1>): Parser<T1> | null {
     }) as HelpersWithContext["has"],
     hasOptional: ((_t: object, k: PropertyKey, guard?: (v: unknown) => boolean) => {
       if (failed) return true;
+
       if (guard && hasContext(guard as Predicate<unknown>)) {
-        const g = guard as unknown as TypeGuard<unknown>;
+        const g = guard as TypeGuard<unknown>;
         if (g.optional) {
-          fields.push({ kind: "typeGuard", key: String(k), guard: g.optional as unknown as TypeGuard<unknown> });
+          fields.push({
+            kind: "typeGuard",
+            key: String(k),
+            guard: g.optional as TypeGuard<unknown>,
+          });
         } else {
           fields.push(classifyGuard(String(k), guard));
         }
       } else if (guard) {
-        fields.push({ kind: "typePredicate", key: String(k), guard: guard as (v: unknown) => boolean });
+        fields.push({ kind: "typePredicate", key: String(k), guard });
       }
       return true;
     }) as HelpersWithContext["hasOptional"],
     hasNot: ((_t: object, k: PropertyKey) => {
       if (failed) return true;
+
       fields.push({ kind: "absent", key: String(k) });
       return true;
     }) as HelpersWithContext["hasNot"],
@@ -663,10 +652,10 @@ function tryCompileParser<T1>(parser: Parser<T1>): Parser<T1> | null {
   // but fall back to the original parser for the validate path to preserve
   // exact behavioral parity (original object returned, custom error messages, etc.)
   return (val: unknown, helpers: HelpersWithContext) => {
-    const ctx = helpers._ctx;
-    if (ctx === undefined) {
+    if (helpers._ctx === undefined) {
       return validateCompiledShapeBoolean(val, fields) ? (val as T1) : null;
     }
+
     // Validate path: use original parser to preserve exact error messages and return value
     return parser(val, helpers);
   };
@@ -685,10 +674,29 @@ function compileShapeParser<T1>(shape: TypeGuardShape): Parser<T1> {
     }
     // Slow path: caller wants issue tracking via .validate() or nested validation.
     const result = validateCompiledShape(val, fields, ctx);
+
     return "value" in result ? result.value as T1 : null;
   };
 }
 
+/**
+ * Creates a type guard from a parser function.
+ *
+ * The parser should perform whatever checks are necessary to safely establish
+ * that the input is of the specified type.
+ *
+ * Injects the `has` utility method as the second argument of any parser, as
+ * a convenience to check if a property exists in an object.
+ *
+ * @param parser A function that returns the value if valid, or null if invalid.
+ * @returns A type guard function with utility methods.
+ *
+ * @example
+ * ```typescript
+ * const parseString = (val: unknown): string | null => typeof val === 'string' ? val : null;
+ * const isString = createTypeGuard(parseString);
+ * ```
+ */
 export function createTypeGuard<T1>(parser: Parser<T1>): TypeGuard<T1>;
 /**
  * Creates a type guard from a parser function with a custom type name.
@@ -876,11 +884,12 @@ export function createTypeGuard<T1>(
    */
   callback.notEmpty = createNotEmptyTypeGuard(callback);
 
-  type OptionalTypeGuard = ReturnType<typeof createOptionalTypeGuard<T1>> & {
-    notEmpty: typeof callback.notEmpty.optional;
-  };
+  const optional = createOptionalTypeGuard(callback, parser, context) as
+    & ReturnType<typeof createOptionalTypeGuard<T1>>
+    & {
+      notEmpty: typeof callback.notEmpty.optional;
+    };
 
-  const optional = createOptionalTypeGuard(callback, parser, context) as OptionalTypeGuard;
   optional.notEmpty = callback.notEmpty.optional;
   callback.optional = optional;
 


### PR DESCRIPTION
## Summary

- Probe parser callbacks at `createTypeGuard` time using a Proxy-based probe that records `has`/`hasOptional`/`hasNot` calls as `FieldDescriptor[]`
- When the parser follows a compilable pattern (isObject + unconditional has-chain, returning value unchanged), the boolean fast-fail path routes through `validateCompiledShapeBoolean` — the same infrastructure shape guards use
- Non-compilable parsers (data-dependent property access, transforms, exotic helpers) are detected via Proxy `get`/`ownKeys` traps and fall back silently to the original closure-based path
- Validate path falls through to the original parser to preserve exact behavioral parity (error messages, return values)
- Extends `FieldDescriptor` with `required` and `absent` kinds for `has()` without guard and `hasNot()` patterns

### Fast-fail benchmark results (before → after)

| Scenario | Before (shape faster by) | After |
|----------|-------------------------|-------|
| Flat valid | 1.21x | **1.04x** (parity) |
| Flat invalid | 1.87x | **1.03x parser faster** |
| Nested valid | **5.13x** | **1.05x parser faster** |
| Nested invalid | 1.99x | 1.26x |
| Deep valid | **3.70x** | **1.05x** (parity) |
| Deep invalid | 1.66x | **1.01x** (parity) |

## Test plan

- [x] All 76 existing + new tests pass (`deno test` — 0 failures)
- [x] New `Parser auto-compilation safety` test block with 9 cases covering:
  - Data-dependent property access (`v.age < 18`) — bails via Proxy `get` trap
  - `Object.keys(v)` enumeration — bails via Proxy `ownKeys` trap
  - Value transformation — bails via `result !== probe`
  - `fail()` / `includes()` helpers — bails via helper flags
  - Compilable has-chain parity with shape guards
  - `hasOptional` / `hasNot` / nested guard compilation
- [x] `deno task bench:parser-vs-shape` confirms parity