### PR TITLE
feat(guardis): add plugin system for createTypeGuard

### DIFF
--- a/packages/guardis/benchmarks/parser-vs-shape.bench.ts
+++ b/packages/guardis/benchmarks/parser-vs-shape.bench.ts
@@ -1,0 +1,402 @@
+import {
+  createTypeGuard,
+  isArray,
+  isBoolean,
+  isNumber,
+  isObject,
+  isString,
+} from "../src/guard.ts";
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+// --- Flat (5 fields) -------------------------------------------------------
+
+const FLAT_VALID = {
+  name: "Alice",
+  age: 30,
+  active: true,
+  score: 95.5,
+  email: "alice@example.com",
+};
+
+const FLAT_INVALID = {
+  name: 123,
+  age: "thirty",
+  active: "yes",
+  score: null,
+  email: 42,
+};
+
+// --- Nested (3 levels, 14 fields) ------------------------------------------
+
+const NESTED_VALID = {
+  user: {
+    name: "Alice",
+    email: "alice@example.com",
+    age: 30,
+    active: true,
+  },
+  address: {
+    street: "123 Main St",
+    city: "Springfield",
+    state: "IL",
+    zip: "62701",
+  },
+  tags: ["admin", "verified"],
+  metadata: {
+    source: "web",
+    version: 2,
+    referral: "campaign-123",
+  },
+};
+
+const NESTED_INVALID = {
+  user: { name: 42, email: true, age: "old", active: "yes" },
+  address: { street: 100, city: null, state: 5, zip: false },
+  tags: "not-an-array",
+  metadata: { source: 999, version: "two", referral: null },
+};
+
+// --- Deep (5 levels, 26 fields) --------------------------------------------
+
+const DEEP_VALID = {
+  id: 1,
+  name: "Acme Corp",
+  active: true,
+  config: {
+    theme: "dark",
+    version: 3,
+    features: {
+      dashboard: true,
+      analytics: true,
+      notifications: {
+        email: true,
+        sms: false,
+        push: {
+          enabled: true,
+          provider: "firebase",
+          retries: 3,
+        },
+      },
+    },
+  },
+  tags: ["enterprise", "premium"],
+  contacts: {
+    primary: {
+      name: "Bob",
+      email: "bob@acme.com",
+      phone: "555-1234",
+    },
+    billing: {
+      name: "Carol",
+      email: "carol@acme.com",
+      phone: "555-5678",
+    },
+  },
+};
+
+const DEEP_INVALID = {
+  id: "not-a-number",
+  name: 42,
+  active: "yes",
+  config: {
+    theme: 123,
+    version: "three",
+    features: {
+      dashboard: "yes",
+      analytics: 1,
+      notifications: {
+        email: "yes",
+        sms: 0,
+        push: {
+          enabled: "true",
+          provider: 999,
+          retries: "three",
+        },
+      },
+    },
+  },
+  tags: "not-an-array",
+  contacts: {
+    primary: { name: 1, email: false, phone: 0 },
+    billing: { name: 2, email: null, phone: true },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Parser guards
+// ---------------------------------------------------------------------------
+
+type Flat = { name: string; age: number; active: boolean; score: number; email: string };
+
+const flatParser = createTypeGuard<Flat>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "name", isString) &&
+    has(v, "age", isNumber) &&
+    has(v, "active", isBoolean) &&
+    has(v, "score", isNumber) &&
+    has(v, "email", isString)
+  ) return v;
+  return null;
+});
+
+type User = { name: string; email: string; age: number; active: boolean };
+type Address = { street: string; city: string; state: string; zip: string };
+type Metadata = { source: string; version: number; referral: string };
+type Nested = { user: User; address: Address; tags: string[]; metadata: Metadata };
+
+const nestedUserParser = createTypeGuard<User>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "name", isString) &&
+    has(v, "email", isString) &&
+    has(v, "age", isNumber) &&
+    has(v, "active", isBoolean)
+  ) return v;
+  return null;
+});
+
+const nestedAddressParser = createTypeGuard<Address>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "street", isString) &&
+    has(v, "city", isString) &&
+    has(v, "state", isString) &&
+    has(v, "zip", isString)
+  ) return v;
+  return null;
+});
+
+const nestedMetadataParser = createTypeGuard<Metadata>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "source", isString) &&
+    has(v, "version", isNumber) &&
+    has(v, "referral", isString)
+  ) return v;
+  return null;
+});
+
+const nestedParser = createTypeGuard<Nested>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "user", nestedUserParser) &&
+    has(v, "address", nestedAddressParser) &&
+    has(v, "tags", isArray.of(isString)) &&
+    has(v, "metadata", nestedMetadataParser)
+  ) return v;
+  return null;
+});
+
+type Push = { enabled: boolean; provider: string; retries: number };
+type Notifications = { email: boolean; sms: boolean; push: Push };
+type Features = { dashboard: boolean; analytics: boolean; notifications: Notifications };
+type Config = { theme: string; version: number; features: Features };
+type Contact = { name: string; email: string; phone: string };
+type Contacts = { primary: Contact; billing: Contact };
+type Deep = {
+  id: number;
+  name: string;
+  active: boolean;
+  config: Config;
+  tags: string[];
+  contacts: Contacts;
+};
+
+const deepPushParser = createTypeGuard<Push>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "enabled", isBoolean) &&
+    has(v, "provider", isString) &&
+    has(v, "retries", isNumber)
+  ) return v;
+  return null;
+});
+
+const deepNotificationsParser = createTypeGuard<Notifications>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "email", isBoolean) &&
+    has(v, "sms", isBoolean) &&
+    has(v, "push", deepPushParser)
+  ) return v;
+  return null;
+});
+
+const deepFeaturesParser = createTypeGuard<Features>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "dashboard", isBoolean) &&
+    has(v, "analytics", isBoolean) &&
+    has(v, "notifications", deepNotificationsParser)
+  ) return v;
+  return null;
+});
+
+const deepConfigParser = createTypeGuard<Config>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "theme", isString) &&
+    has(v, "version", isNumber) &&
+    has(v, "features", deepFeaturesParser)
+  ) return v;
+  return null;
+});
+
+const deepContactParser = createTypeGuard<Contact>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "name", isString) &&
+    has(v, "email", isString) &&
+    has(v, "phone", isString)
+  ) return v;
+  return null;
+});
+
+const deepContactsParser = createTypeGuard<Contacts>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "primary", deepContactParser) &&
+    has(v, "billing", deepContactParser)
+  ) return v;
+  return null;
+});
+
+const deepParser = createTypeGuard<Deep>((v, { has }) => {
+  if (
+    isObject(v) &&
+    has(v, "id", isNumber) &&
+    has(v, "name", isString) &&
+    has(v, "active", isBoolean) &&
+    has(v, "config", deepConfigParser) &&
+    has(v, "tags", isArray.of(isString)) &&
+    has(v, "contacts", deepContactsParser)
+  ) return v;
+  return null;
+});
+
+// ---------------------------------------------------------------------------
+// Shape guards
+// ---------------------------------------------------------------------------
+
+const flatShape = createTypeGuard({
+  name: isString,
+  age: isNumber,
+  active: isBoolean,
+  score: isNumber,
+  email: isString,
+});
+
+const nestedShape = createTypeGuard({
+  user: {
+    name: isString,
+    email: isString,
+    age: isNumber,
+    active: isBoolean,
+  },
+  address: {
+    street: isString,
+    city: isString,
+    state: isString,
+    zip: isString,
+  },
+  tags: isArray.of(isString),
+  metadata: {
+    source: isString,
+    version: isNumber,
+    referral: isString,
+  },
+});
+
+const deepShape = createTypeGuard({
+  id: isNumber,
+  name: isString,
+  active: isBoolean,
+  config: {
+    theme: isString,
+    version: isNumber,
+    features: {
+      dashboard: isBoolean,
+      analytics: isBoolean,
+      notifications: {
+        email: isBoolean,
+        sms: isBoolean,
+        push: {
+          enabled: isBoolean,
+          provider: isString,
+          retries: isNumber,
+        },
+      },
+    },
+  },
+  tags: isArray.of(isString),
+  contacts: {
+    primary: {
+      name: isString,
+      email: isString,
+      phone: isString,
+    },
+    billing: {
+      name: isString,
+      email: isString,
+      phone: isString,
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Flat — fast-fail (boolean)
+// ---------------------------------------------------------------------------
+
+Deno.bench({ name: "flat | parser  | valid   | fast-fail", group: "flat-valid",   fn() { flatParser(FLAT_VALID); } });
+Deno.bench({ name: "flat | shape   | valid   | fast-fail", group: "flat-valid",   fn() { flatShape(FLAT_VALID); } });
+Deno.bench({ name: "flat | parser  | invalid | fast-fail", group: "flat-invalid", fn() { flatParser(FLAT_INVALID); } });
+Deno.bench({ name: "flat | shape   | invalid | fast-fail", group: "flat-invalid", fn() { flatShape(FLAT_INVALID); } });
+
+// ---------------------------------------------------------------------------
+// Flat — validate (StandardSchema result)
+// ---------------------------------------------------------------------------
+
+Deno.bench({ name: "flat | parser  | valid   | validate",  group: "flat-valid-v",   fn() { flatParser.validate(FLAT_VALID); } });
+Deno.bench({ name: "flat | shape   | valid   | validate",  group: "flat-valid-v",   fn() { flatShape.validate(FLAT_VALID); } });
+Deno.bench({ name: "flat | parser  | invalid | validate",  group: "flat-invalid-v", fn() { flatParser.validate(FLAT_INVALID); } });
+Deno.bench({ name: "flat | shape   | invalid | validate",  group: "flat-invalid-v", fn() { flatShape.validate(FLAT_INVALID); } });
+
+// ---------------------------------------------------------------------------
+// Nested — fast-fail (boolean)
+// ---------------------------------------------------------------------------
+
+Deno.bench({ name: "nested | parser  | valid   | fast-fail", group: "nested-valid",   fn() { nestedParser(NESTED_VALID); } });
+Deno.bench({ name: "nested | shape   | valid   | fast-fail", group: "nested-valid",   fn() { nestedShape(NESTED_VALID); } });
+Deno.bench({ name: "nested | parser  | invalid | fast-fail", group: "nested-invalid", fn() { nestedParser(NESTED_INVALID); } });
+Deno.bench({ name: "nested | shape   | invalid | fast-fail", group: "nested-invalid", fn() { nestedShape(NESTED_INVALID); } });
+
+// ---------------------------------------------------------------------------
+// Nested — validate (StandardSchema result)
+// ---------------------------------------------------------------------------
+
+Deno.bench({ name: "nested | parser  | valid   | validate",  group: "nested-valid-v",   fn() { nestedParser.validate(NESTED_VALID); } });
+Deno.bench({ name: "nested | shape   | valid   | validate",  group: "nested-valid-v",   fn() { nestedShape.validate(NESTED_VALID); } });
+Deno.bench({ name: "nested | parser  | invalid | validate",  group: "nested-invalid-v", fn() { nestedParser.validate(NESTED_INVALID); } });
+Deno.bench({ name: "nested | shape   | invalid | validate",  group: "nested-invalid-v", fn() { nestedShape.validate(NESTED_INVALID); } });
+
+// ---------------------------------------------------------------------------
+// Deep — fast-fail (boolean)
+// ---------------------------------------------------------------------------
+
+Deno.bench({ name: "deep | parser  | valid   | fast-fail", group: "deep-valid",   fn() { deepParser(DEEP_VALID); } });
+Deno.bench({ name: "deep | shape   | valid   | fast-fail", group: "deep-valid",   fn() { deepShape(DEEP_VALID); } });
+Deno.bench({ name: "deep | parser  | invalid | fast-fail", group: "deep-invalid", fn() { deepParser(DEEP_INVALID); } });
+Deno.bench({ name: "deep | shape   | invalid | fast-fail", group: "deep-invalid", fn() { deepShape(DEEP_INVALID); } });
+
+// ---------------------------------------------------------------------------
+// Deep — validate (StandardSchema result)
+// ---------------------------------------------------------------------------
+
+Deno.bench({ name: "deep | parser  | valid   | validate",  group: "deep-valid-v",   fn() { deepParser.validate(DEEP_VALID); } });
+Deno.bench({ name: "deep | shape   | valid   | validate",  group: "deep-valid-v",   fn() { deepShape.validate(DEEP_VALID); } });
+Deno.bench({ name: "deep | parser  | invalid | validate",  group: "deep-invalid-v", fn() { deepParser.validate(DEEP_INVALID); } });
+Deno.bench({ name: "deep | shape   | invalid | validate",  group: "deep-invalid-v", fn() { deepShape.validate(DEEP_INVALID); } });

--- a/packages/guardis/deno.json
+++ b/packages/guardis/deno.json
@@ -16,13 +16,17 @@
       "description": "Run unit tests.",
       "command": "deno test"
     },
-    "bench:all": {
-      "description": "Run all library benchmarks on the typeguards to detect slow parsing logic.",
-      "command": "deno bench benchmarks/guard*.bench.ts"
+    "bench:competitors": {
+      "description": "Run comparative benchmarks against Zod, ArkType, and Valibot.",
+      "command": "deno bench --config ../benchmarks/deno.json ../benchmarks/"
     },
-    "bench:guards": {
-      "description": "Run library benchmarks on the typeguards to detect slow parsing logic.",
-      "command": "deno bench benchmarks/guard.bench.ts"
+    "bench:primitives": {
+      "description": "Benchmark primitive type guards.",
+      "command": "deno bench benchmarks/guard.bench.ts benchmarks/guard.json.bench.ts benchmarks/guard.jsonArray.bench.ts"
+    },
+    "bench:parser-vs-shape": {
+      "description": "Benchmark parser vs shape object validation across complexity levels.",
+      "command": "deno bench benchmarks/parser-vs-shape.bench.ts"
     },
     "build:npm": {
       "description": "Build npm package using dnt.",

--- a/packages/guardis/mod.ts
+++ b/packages/guardis/mod.ts
@@ -7,6 +7,7 @@
  */
 
 export * from "./src/guard.ts";
+export * from "./src/plugin.ts";
 export * from "./src/extend.ts";
 export * from "./src/batch.ts";
 export * from "./src/brand.ts";

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -28,6 +28,7 @@ import type {
   VerifiedShape,
 } from "./types.ts";
 import { createContext, createStrictContext } from "./context.ts";
+import type { AnyPlugin, ExtendedFactory } from "./plugin.ts";
 import { hasContext, hasName } from "./introspect.ts";
 import {
   doesNotHaveProperty,
@@ -1269,3 +1270,98 @@ isTupleOptional.assert = isTupleOptional.strict;
 isTuple.optional = isTupleOptional;
 
 export { isEmpty, isIterable, isNil, isNull, isTuple };
+
+/** Checks if a value looks like a TypeGuardShape (plain object, not function/array) */
+function isPluginPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value) &&
+    typeof value !== "function";
+}
+
+/** Checks if a plain object has at least one guard-like value (function or nested object) */
+function looksLikeShape(value: Record<string, unknown>): boolean {
+  const keys = Object.keys(value);
+  if (keys.length === 0) return false;
+  for (const key of keys) {
+    const v = value[key];
+    if (typeof v === "function") return true;
+    if (isPluginPlainObject(v)) return true;
+  }
+  return false;
+}
+
+/**
+ * Creates an extended factory function that applies plugins to every guard it creates.
+ * Validates that all plugin IDs are unique (throws TypeError on duplicates).
+ */
+function _withPlugins<const Plugins extends readonly AnyPlugin[]>(
+  ...plugins: Plugins
+): ExtendedFactory<Plugins> {
+  const ids = new Set<string>();
+  for (const plugin of plugins) {
+    if (ids.has(plugin.id)) {
+      throw new TypeError(`Duplicate plugin id: "${plugin.id}"`);
+    }
+    ids.add(plugin.id);
+  }
+
+  // deno-lint-ignore no-explicit-any
+  const factory = (...args: any[]): any => {
+    let name: string | undefined;
+    let parserOrShape: Parser | TypeGuardShape;
+    // deno-lint-ignore no-explicit-any
+    let pluginOptions: any;
+
+    if (typeof args[0] === "string") {
+      name = args[0];
+      parserOrShape = args[1];
+      pluginOptions = args[2];
+    } else if (typeof args[0] === "function") {
+      parserOrShape = args[0];
+      pluginOptions = args[1];
+    } else if (isPluginPlainObject(args[0])) {
+      if (args.length === 1 && looksLikeShape(args[0] as Record<string, unknown>)) {
+        parserOrShape = args[0] as TypeGuardShape;
+        pluginOptions = undefined;
+      } else if (args.length === 2) {
+        parserOrShape = args[0] as TypeGuardShape;
+        pluginOptions = args[1];
+      } else {
+        parserOrShape = args[0] as TypeGuardShape;
+        pluginOptions = undefined;
+      }
+    } else {
+      throw new TypeError("Invalid arguments to extended factory");
+    }
+
+    const pluginData: Record<string, unknown> = {};
+    let currentArgs: Parser | TypeGuardShape = parserOrShape;
+
+    for (const plugin of plugins) {
+      const result = plugin.init(name, currentArgs, pluginOptions);
+      currentArgs = result.args;
+      pluginData[plugin.id] = result.data;
+    }
+
+    const guard = name !== undefined
+      ? createTypeGuard(name, currentArgs as Parser)
+      : createTypeGuard(currentArgs as Parser);
+
+    guard._.plugins = pluginData;
+
+    return guard;
+  };
+
+  return factory as ExtendedFactory<Plugins>;
+}
+
+// Attach withPlugins as a static method on createTypeGuard
+// deno-lint-ignore no-explicit-any
+(createTypeGuard as any).withPlugins = _withPlugins;
+
+// Declaration merge: makes TypeScript aware of the .withPlugins static method
+// deno-lint-ignore no-namespace no-explicit-any
+export namespace createTypeGuard {
+  export declare function withPlugins<const Plugins extends readonly import("./plugin.ts").GuardPlugin<string, any, any>[]>(
+    ...plugins: Plugins
+  ): import("./plugin.ts").ExtendedFactory<Plugins>;
+}

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -1293,7 +1293,7 @@ function looksLikeShape(value: Record<string, unknown>): boolean {
  * Creates an extended factory function that applies plugins to every guard it creates.
  * Validates that all plugin IDs are unique (throws TypeError on duplicates).
  */
-function _withPlugins<const Plugins extends readonly AnyPlugin[]>(
+function withPluginsImpl<const Plugins extends readonly AnyPlugin[]>(
   ...plugins: Plugins
 ): ExtendedFactory<Plugins> {
   const ids = new Set<string>();
@@ -1330,7 +1330,7 @@ function _withPlugins<const Plugins extends readonly AnyPlugin[]>(
         pluginOptions = undefined;
       }
     } else {
-      throw new TypeError("Invalid arguments to extended factory");
+      throw new TypeError("Invalid arguments to extended factory: first argument must be a name (string), parser (function), or shape (plain object)");
     }
 
     const pluginData: Record<string, unknown> = {};
@@ -1342,9 +1342,11 @@ function _withPlugins<const Plugins extends readonly AnyPlugin[]>(
       pluginData[plugin.id] = result.data;
     }
 
-    const guard = name !== undefined
-      ? createTypeGuard(name, currentArgs as Parser)
-      : createTypeGuard(currentArgs as Parser);
+    const guard = typeof currentArgs === "function"
+      ? (name !== undefined ? createTypeGuard(name, currentArgs) : createTypeGuard(currentArgs))
+      : (name !== undefined
+        ? createTypeGuard(name, currentArgs as TypeGuardShape)
+        : createTypeGuard(currentArgs as TypeGuardShape));
 
     guard._.plugins = pluginData;
 
@@ -1356,11 +1358,28 @@ function _withPlugins<const Plugins extends readonly AnyPlugin[]>(
 
 // Attach withPlugins as a static method on createTypeGuard
 // deno-lint-ignore no-explicit-any
-(createTypeGuard as any).withPlugins = _withPlugins;
+(createTypeGuard as any).withPlugins = withPluginsImpl;
 
 // Declaration merge: makes TypeScript aware of the .withPlugins static method
 // deno-lint-ignore no-namespace no-explicit-any
 export namespace createTypeGuard {
+  /**
+   * Creates an extended factory that applies plugins to every guard it creates.
+   * Each plugin's `init` hook runs once at guard creation time, attaching typed
+   * metadata to `guard._.plugins[pluginId]`.
+   *
+   * @param plugins One or more GuardPlugin instances with unique IDs
+   * @returns An extended factory with the same overloads as createTypeGuard,
+   *          plus an optional plugin options argument
+   * @throws TypeError if two plugins share the same id
+   *
+   * @example
+   * ```typescript
+   * const create = createTypeGuard.withPlugins(myPlugin);
+   * const isUser = create("User", { name: isString }, { description: "A user" });
+   * isUser._.plugins.myPluginId // typed metadata from the plugin
+   * ```
+   */
   export declare function withPlugins<const Plugins extends readonly import("./plugin.ts").GuardPlugin<string, any, any>[]>(
     ...plugins: Plugins
   ): import("./plugin.ts").ExtendedFactory<Plugins>;

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -1277,17 +1277,6 @@ function isPluginPlainObject(value: unknown): value is Record<string, unknown> {
     typeof value !== "function";
 }
 
-/** Checks if a plain object has at least one guard-like value (function or nested object) */
-function looksLikeShape(value: Record<string, unknown>): boolean {
-  const keys = Object.keys(value);
-  if (keys.length === 0) return false;
-  for (const key of keys) {
-    const v = value[key];
-    if (typeof v === "function") return true;
-    if (isPluginPlainObject(v)) return true;
-  }
-  return false;
-}
 
 /**
  * Creates an extended factory function that applies plugins to every guard it creates.
@@ -1319,16 +1308,10 @@ function withPluginsImpl<const Plugins extends readonly AnyPlugin[]>(
       parserOrShape = args[0];
       pluginOptions = args[1];
     } else if (isPluginPlainObject(args[0])) {
-      if (args.length === 1 && looksLikeShape(args[0] as Record<string, unknown>)) {
-        parserOrShape = args[0] as TypeGuardShape;
-        pluginOptions = undefined;
-      } else if (args.length === 2) {
-        parserOrShape = args[0] as TypeGuardShape;
-        pluginOptions = args[1];
-      } else {
-        parserOrShape = args[0] as TypeGuardShape;
-        pluginOptions = undefined;
-      }
+      // A plain object as first arg is always a shape — you can't create a guard
+      // from just plugin options. Second arg (if present) is plugin options.
+      parserOrShape = args[0] as TypeGuardShape;
+      pluginOptions = args[1];
     } else {
       throw new TypeError("Invalid arguments to extended factory: first argument must be a name (string), parser (function), or shape (plain object)");
     }

--- a/packages/guardis/src/plugin.test.ts
+++ b/packages/guardis/src/plugin.test.ts
@@ -1,0 +1,120 @@
+import { assertType, type Equals } from "./test-utils.ts";
+import type { GuardPlugin, MergePluginData, MergePluginOptions } from "./plugin.ts";
+import type { GuardMeta, Parser, TypeGuardShape } from "./types.ts";
+
+Deno.test("plugin types", async (t) => {
+  await t.step("GuardPlugin with id, init returning string data compiles and infers TData", () => {
+    const plugin: GuardPlugin<"test", string> = {
+      id: "test",
+      init(_name, args, _options) {
+        return { args, data: "hello" };
+      },
+    };
+    assertType<Equals<typeof plugin.id, "test">>();
+
+    const result = plugin.init(undefined, ((v: unknown) => v) as Parser, undefined as void);
+    assertType<Equals<typeof result.data, string>>();
+  });
+
+  await t.step("GuardPlugin with options compiles", () => {
+    const plugin: GuardPlugin<"desc", Record<string, string>, { description: string }> = {
+      id: "desc",
+      init(_name, args, options) {
+        return { args, data: { field: options.description } };
+      },
+    };
+
+    const result = plugin.init("test", ((v: unknown) => v) as Parser, {
+      description: "a description",
+    });
+    assertType<Equals<typeof result.data, Record<string, string>>>();
+  });
+
+  await t.step("GuardPlugin init accepts TypeGuardShape args", () => {
+    const plugin: GuardPlugin<"meta", string> = {
+      id: "meta",
+      init(_name, args, _options) {
+        // Plugin can check if args is a shape or parser
+        if (typeof args === "object") {
+          return { args, data: "shape" };
+        }
+        return { args, data: "parser" };
+      },
+    };
+
+    const shape: TypeGuardShape = { name: (_v: unknown): _v is string => typeof _v === "string" };
+    const result = plugin.init(undefined, shape, undefined as void);
+    assertType<Equals<typeof result.data, string>>();
+  });
+
+  await t.step("MergePluginData produces correct keyed structure from two plugins", () => {
+    type PluginA = GuardPlugin<"a", string>;
+    type PluginB = GuardPlugin<"b", number>;
+    type Merged = MergePluginData<[PluginA, PluginB]>;
+
+    assertType<Equals<Merged, { a: string; b: number }>>();
+  });
+
+  await t.step("MergePluginData works with a single plugin", () => {
+    type PluginA = GuardPlugin<"only", boolean>;
+    type Merged = MergePluginData<[PluginA]>;
+
+    assertType<Equals<Merged, { only: boolean }>>();
+  });
+
+  await t.step("MergePluginOptions merges options from two plugins", () => {
+    type PluginA = GuardPlugin<"a", string, { fieldA: string }>;
+    type PluginB = GuardPlugin<"b", number, { fieldB: number }>;
+    type Merged = MergePluginOptions<[PluginA, PluginB]>;
+
+    assertType<Equals<Merged, { fieldA: string } & { fieldB: number }>>();
+  });
+
+  await t.step("MergePluginOptions omits void options plugins", () => {
+    type PluginNoOpts = GuardPlugin<"noOpts", string>;
+    type PluginWithOpts = GuardPlugin<"withOpts", number, { setting: boolean }>;
+    type Merged = MergePluginOptions<[PluginNoOpts, PluginWithOpts]>;
+
+    assertType<Equals<Merged, { setting: boolean }>>();
+  });
+
+  await t.step("MergePluginOptions with all void options produces empty object", () => {
+    type PluginA = GuardPlugin<"a", string>;
+    type PluginB = GuardPlugin<"b", number>;
+    type Merged = MergePluginOptions<[PluginA, PluginB]>;
+
+    // deno-lint-ignore ban-types
+    assertType<Equals<Merged, {}>>();
+  });
+
+  await t.step("GuardMeta plugins field is optional and typed as Record<string, unknown>", () => {
+    type Meta = GuardMeta<string>;
+
+    // plugins is optional
+    assertType<Equals<Meta["plugins"], Record<string, unknown> | undefined>>();
+
+    // GuardMeta without plugins set is valid
+    const meta: Meta = {
+      name: "test",
+      parser: (_v: unknown) => null,
+      context: (_v: unknown) => ({ value: "" as string, issues: undefined }),
+    };
+    assertType<Equals<typeof meta.plugins, Record<string, unknown> | undefined>>();
+  });
+
+  await t.step("GuardMeta with plugins set infers correctly", () => {
+    const meta: GuardMeta<string> = {
+      name: "test",
+      parser: (_v: unknown) => null,
+      context: (_v: unknown) => ({ value: "" as string, issues: undefined }),
+      plugins: { desc: "hello", schema: { type: "string" } },
+    };
+
+    // plugins is present and is Record<string, unknown>
+    assertType<Equals<typeof meta.plugins, Record<string, unknown> | undefined>>();
+    // At runtime, it's set
+    if (meta.plugins) {
+      const _desc: unknown = meta.plugins["desc"];
+    }
+  });
+});

--- a/packages/guardis/src/plugin.test.ts
+++ b/packages/guardis/src/plugin.test.ts
@@ -1,6 +1,8 @@
 import { assertType, type Equals } from "./test-utils.ts";
 import type { GuardPlugin, MergePluginData, MergePluginOptions } from "./plugin.ts";
 import type { GuardMeta, Parser, TypeGuardShape } from "./types.ts";
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { createTypeGuard, isNumber, isString } from "./guard.ts";
 
 Deno.test("plugin types", async (t) => {
   await t.step("GuardPlugin with id, init returning string data compiles and infers TData", () => {
@@ -116,5 +118,325 @@ Deno.test("plugin types", async (t) => {
     if (meta.plugins) {
       const _desc: unknown = meta.plugins["desc"];
     }
+  });
+});
+
+// -- Unit 2: withPlugins runtime tests --
+
+/** Simple plugin that records creation metadata */
+function createMetaPlugin(): GuardPlugin<"meta", { createdWith: string }> {
+  return {
+    id: "meta",
+    init(name, args, _options) {
+      return { args, data: { createdWith: name ?? "anonymous" } };
+    },
+  };
+}
+
+/** Plugin that accepts options */
+function createLabelPlugin(): GuardPlugin<"label", string, { label: string }> {
+  return {
+    id: "label",
+    init(_name, args, options) {
+      return { args, data: options?.label ?? "unlabeled" };
+    },
+  };
+}
+
+Deno.test("withPlugins - single plugin", async (t) => {
+  await t.step("returns a function", () => {
+    const metaPlugin = createMetaPlugin();
+    const factory = createTypeGuard.withPlugins(metaPlugin);
+    assertEquals(typeof factory, "function");
+  });
+
+  await t.step("extended factory creates guard with plugin data from parser", () => {
+    const metaPlugin = createMetaPlugin();
+    const factory = createTypeGuard.withPlugins(metaPlugin);
+    const guard = factory((v: unknown): string | null => typeof v === "string" ? v : null);
+
+    assert(guard("hello"));
+    assert(!guard(42));
+    assertEquals(guard._.plugins?.meta, { createdWith: "anonymous" });
+  });
+
+  await t.step("extended factory with named guard passes name to init", () => {
+    const metaPlugin = createMetaPlugin();
+    const factory = createTypeGuard.withPlugins(metaPlugin);
+    const guard = factory("myGuard", (v: unknown): string | null => typeof v === "string" ? v : null);
+
+    assert(guard("hello"));
+    assertEquals(guard._.plugins?.meta, { createdWith: "myGuard" });
+    assertEquals(guard._.name, "myGuard");
+  });
+
+  await t.step("extended factory with shape creates working guard with plugin data", () => {
+    const metaPlugin = createMetaPlugin();
+    const factory = createTypeGuard.withPlugins(metaPlugin);
+    const guard = factory({ name: isString, age: isNumber });
+
+    assert(guard({ name: "Alice", age: 30 }));
+    assert(!guard({ name: "Alice" }));
+    assert(!guard("not an object"));
+    assertEquals(guard._.plugins?.meta, { createdWith: "anonymous" });
+  });
+
+  await t.step("extended factory with named shape", () => {
+    const metaPlugin = createMetaPlugin();
+    const factory = createTypeGuard.withPlugins(metaPlugin);
+    const guard = factory("Person", { name: isString, age: isNumber });
+
+    assert(guard({ name: "Bob", age: 25 }));
+    assertEquals(guard._.plugins?.meta, { createdWith: "Person" });
+    assertEquals(guard._.name, "Person");
+  });
+
+  await t.step("plugin options passed as last arg are forwarded to init", () => {
+    const labelPlugin = createLabelPlugin();
+    const factory = createTypeGuard.withPlugins(labelPlugin);
+    const guard = factory(
+      (v: unknown): string | null => typeof v === "string" ? v : null,
+      { label: "my-label" },
+    );
+
+    assert(guard("hello"));
+    assertEquals(guard._.plugins?.label, "my-label");
+  });
+
+  await t.step("extended factory without plugin options — init receives undefined", () => {
+    const labelPlugin = createLabelPlugin();
+    const factory = createTypeGuard.withPlugins(labelPlugin);
+    const guard = factory((v: unknown): string | null => typeof v === "string" ? v : null);
+
+    assert(guard("test"));
+    assertEquals(guard._.plugins?.label, "unlabeled");
+  });
+
+  await t.step("guard has all standard properties", () => {
+    const metaPlugin = createMetaPlugin();
+    const factory = createTypeGuard.withPlugins(metaPlugin);
+    const guard = factory({ name: isString });
+
+    // Check all standard methods exist
+    assertEquals(typeof guard.strict, "function");
+    assertEquals(typeof guard.assert, "function");
+    assertEquals(typeof guard.validate, "function");
+    assertEquals(typeof guard.or, "function");
+    assertEquals(typeof guard.extend, "function");
+    assertEquals(typeof guard.optional, "function");
+    assert("notEmpty" in guard);
+  });
+
+  await t.step("guard validates identically to base createTypeGuard", () => {
+    const metaPlugin = createMetaPlugin();
+    const factory = createTypeGuard.withPlugins(metaPlugin);
+
+    const baseGuard = createTypeGuard({ name: isString, age: isNumber });
+    const pluginGuard = factory({ name: isString, age: isNumber });
+
+    const testValues = [
+      { name: "Alice", age: 30 },
+      { name: "Alice" },
+      { age: 30 },
+      "not an object",
+      null,
+      42,
+      { name: 123, age: "thirty" },
+    ];
+
+    for (const val of testValues) {
+      assertEquals(
+        pluginGuard(val),
+        baseGuard(val),
+        `Mismatch for value: ${JSON.stringify(val)}`,
+      );
+    }
+  });
+});
+
+Deno.test("withPlugins - multi-plugin composition", async (t) => {
+  await t.step("two plugins produce both keyed slots with correct data", () => {
+    const metaPlugin = createMetaPlugin();
+    const labelPlugin = createLabelPlugin();
+    const factory = createTypeGuard.withPlugins(metaPlugin, labelPlugin);
+
+    const guard = factory(
+      "test",
+      (v: unknown): string | null => typeof v === "string" ? v : null,
+      { label: "composed" },
+    );
+
+    assert(guard("hello"));
+    assertEquals(guard._.plugins?.meta, { createdWith: "test" });
+    assertEquals(guard._.plugins?.label, "composed");
+  });
+
+  await t.step("options forwarded to respective plugin init calls", () => {
+    const labelPlugin = createLabelPlugin();
+    const metaPlugin = createMetaPlugin();
+    const factory = createTypeGuard.withPlugins(labelPlugin, metaPlugin);
+
+    const guard = factory(
+      (v: unknown): number | null => typeof v === "number" ? v : null,
+      { label: "num-guard" },
+    );
+
+    assert(guard(42));
+    assert(!guard("nope"));
+    assertEquals(guard._.plugins?.label, "num-guard");
+    assertEquals(guard._.plugins?.meta, { createdWith: "anonymous" });
+  });
+
+  await t.step("duplicate plugin id throws TypeError at withPlugins call time", () => {
+    const plugin1: GuardPlugin<"dup", string> = {
+      id: "dup",
+      init(_n, args) { return { args, data: "a" }; },
+    };
+    const plugin2: GuardPlugin<"dup", number> = {
+      id: "dup",
+      init(_n, args) { return { args, data: 1 }; },
+    };
+
+    assertThrows(
+      () => createTypeGuard.withPlugins(plugin1, plugin2),
+      TypeError,
+      'Duplicate plugin id: "dup"',
+    );
+  });
+});
+
+Deno.test("withPlugins - shape transformation via init", async (t) => {
+  /** Plugin that extracts "description" metadata from enriched shape fields */
+  const descriptionPlugin: GuardPlugin<"descriptions", Record<string, string>> = {
+    id: "descriptions",
+    init(_name, args, _options) {
+      if (typeof args === "function") {
+        // Parser — pass through unchanged, return empty data
+        return { args, data: {} };
+      }
+
+      // Shape — extract descriptions and normalize the shape
+      const descriptions: Record<string, string> = {};
+      const normalizedShape: TypeGuardShape = {};
+
+      for (const [key, value] of Object.entries(args)) {
+        if (
+          typeof value === "object" && value !== null && !Array.isArray(value) &&
+          "type" in value && "description" in value
+        ) {
+          const enriched = value as { type: (v: unknown) => boolean; description: string };
+          descriptions[key] = enriched.description;
+          normalizedShape[key] = enriched.type as (v: unknown) => v is unknown;
+        } else {
+          normalizedShape[key] = value as TypeGuardShape[string];
+        }
+      }
+
+      return { args: normalizedShape, data: descriptions };
+    },
+  };
+
+  await t.step("description plugin extracts metadata and normalizes shape", () => {
+    const factory = createTypeGuard.withPlugins(descriptionPlugin);
+
+    const guard = factory({
+      name: { type: isString, description: "Display name" },
+      age: { type: isNumber, description: "Age in years" },
+    } as unknown as TypeGuardShape);
+
+    assert(guard({ name: "Alice", age: 30 }));
+    assert(!guard({ name: "Alice" }));
+    assert(!guard({ name: 123, age: 30 }));
+
+    assertEquals(guard._.plugins?.descriptions, {
+      name: "Display name",
+      age: "Age in years",
+    });
+  });
+
+  await t.step("guard from enriched shape validates values correctly", () => {
+    const factory = createTypeGuard.withPlugins(descriptionPlugin);
+
+    const guard = factory({
+      title: { type: isString, description: "Title of the item" },
+    } as unknown as TypeGuardShape);
+
+    assert(guard({ title: "Hello" }));
+    assert(!guard({ title: 42 }));
+    assert(!guard({}));
+    assert(!guard(null));
+  });
+
+  await t.step("two transforming plugins chained — second receives first's output", () => {
+    let secondPluginReceivedArgs: Parser | TypeGuardShape | undefined;
+
+    const firstPlugin: GuardPlugin<"first", string> = {
+      id: "first",
+      init(_name, args, _options) {
+        if (typeof args === "object") {
+          // Transform by adding a marker
+          return { args: { ...args, _marker: isString }, data: "first-ran" };
+        }
+        return { args, data: "first-ran" };
+      },
+    };
+
+    const secondPlugin: GuardPlugin<"second", string> = {
+      id: "second",
+      init(_name, args, _options) {
+        secondPluginReceivedArgs = args;
+        return { args, data: "second-ran" };
+      },
+    };
+
+    const factory = createTypeGuard.withPlugins(firstPlugin, secondPlugin);
+    const guard = factory({ name: isString });
+
+    // Second plugin should have received the transformed args from first
+    assert(typeof secondPluginReceivedArgs === "object");
+    assert("_marker" in (secondPluginReceivedArgs as TypeGuardShape));
+
+    assertEquals(guard._.plugins?.first, "first-ran");
+    assertEquals(guard._.plugins?.second, "second-ran");
+  });
+
+  await t.step("transforming plugin receiving a parser passes args through", () => {
+    const factory = createTypeGuard.withPlugins(descriptionPlugin);
+    const guard = factory((v: unknown): string | null => typeof v === "string" ? v : null);
+
+    assert(guard("hello"));
+    assert(!guard(42));
+    // Parser path — descriptions should be empty
+    assertEquals(guard._.plugins?.descriptions, {});
+  });
+
+  await t.step("end-to-end: description plugin with guard creation and validation", () => {
+    const factory = createTypeGuard.withPlugins(descriptionPlugin);
+
+    const isUser = factory("User", {
+      name: { type: isString, description: "User's display name" },
+      email: { type: isString, description: "Email address" },
+    } as unknown as TypeGuardShape);
+
+    // Validates correctly
+    assert(isUser({ name: "Alice", email: "alice@example.com" }));
+    assert(!isUser({ name: "Alice" }));
+    assert(!isUser({ email: "alice@example.com" }));
+
+    // Plugin data is present
+    assertEquals(isUser._.plugins?.descriptions, {
+      name: "User's display name",
+      email: "Email address",
+    });
+
+    // Guard name is set
+    assertEquals(isUser._.name, "User");
+
+    // validate() works
+    const result = isUser.validate({ name: "Bob", email: "bob@test.com" });
+    assert("value" in result);
+
+    const failResult = isUser.validate({ name: 123 });
+    assert("issues" in failResult);
   });
 });

--- a/packages/guardis/src/plugin.ts
+++ b/packages/guardis/src/plugin.ts
@@ -1,0 +1,49 @@
+import type { Parser, TypeGuardShape } from "./types.ts";
+
+/**
+ * A plugin that enriches type guards with metadata at creation time.
+ *
+ * @template TId - String literal identifying this plugin (used as key in `_.plugins`)
+ * @template TData - The metadata type this plugin produces
+ * @template TOptions - Options this plugin accepts (void if no options needed)
+ */
+export interface GuardPlugin<TId extends string, TData, TOptions = void> {
+  /** Unique identifier for this plugin, used as key in `_.plugins` */
+  readonly id: TId;
+  /**
+   * Called once at guard creation time. Receives the guard name, parser/shape args,
+   * and plugin-specific options. Returns the (potentially transformed) args and
+   * the plugin's metadata.
+   */
+  init(
+    name: string | undefined,
+    args: Parser | TypeGuardShape,
+    options: TOptions,
+  ): { args: Parser | TypeGuardShape; data: TData };
+}
+
+// deno-lint-ignore no-explicit-any
+type AnyPlugin = GuardPlugin<string, any, any>;
+
+/** Extracts the merged plugin data record from a tuple of plugins. */
+export type MergePluginData<Plugins extends readonly AnyPlugin[]> = {
+  [P in Plugins[number] as P["id"]]: P extends GuardPlugin<string, infer TData, infer _TOpts>
+    ? TData
+    : never;
+};
+
+/** Extracts and merges plugin options, omitting plugins with void options. */
+export type MergePluginOptions<Plugins extends readonly AnyPlugin[]> = MergePluginOptionsInner<
+  Plugins,
+  // deno-lint-ignore ban-types
+  {}
+>;
+
+type MergePluginOptionsInner<
+  Plugins extends readonly AnyPlugin[],
+  Acc,
+> = Plugins extends readonly [infer Head extends AnyPlugin, ...infer Tail extends AnyPlugin[]]
+  ? Head extends GuardPlugin<string, infer _TData, infer TOpts>
+    ? MergePluginOptionsInner<Tail, TOpts extends void ? Acc : Acc & TOpts>
+  : Acc
+  : Acc;

--- a/packages/guardis/src/plugin.ts
+++ b/packages/guardis/src/plugin.ts
@@ -1,4 +1,4 @@
-import type { Parser, TypeGuardShape } from "./types.ts";
+import type { InferShape, Parser, TypeGuard, TypeGuardShape } from "./types.ts";
 
 /**
  * A plugin that enriches type guards with metadata at creation time.
@@ -23,7 +23,7 @@ export interface GuardPlugin<TId extends string, TData, TOptions = void> {
 }
 
 // deno-lint-ignore no-explicit-any
-type AnyPlugin = GuardPlugin<string, any, any>;
+export type AnyPlugin = GuardPlugin<string, any, any>;
 
 /** Extracts the merged plugin data record from a tuple of plugins. */
 export type MergePluginData<Plugins extends readonly AnyPlugin[]> = {
@@ -47,3 +47,24 @@ type MergePluginOptionsInner<
     ? MergePluginOptionsInner<Tail, TOpts extends void ? Acc : Acc & TOpts>
   : Acc
   : Acc;
+
+/**
+ * Type for the extended factory function returned by `withPlugins`.
+ */
+// deno-lint-ignore no-explicit-any
+export type PluginOpts<Plugins extends readonly AnyPlugin[]> = MergePluginOptions<Plugins> extends infer O ? [keyof O] extends [never] ? void : O : void;
+
+export type PluginGuard<T, Plugins extends readonly AnyPlugin[]> = TypeGuard<T> & {
+  _: TypeGuard<T>["_"] & { plugins: MergePluginData<Plugins> };
+};
+
+export interface ExtendedFactory<Plugins extends readonly AnyPlugin[]> {
+  <T>(parser: Parser<T>): PluginGuard<T, Plugins>;
+  <T>(name: string, parser: Parser<T>): PluginGuard<T, Plugins>;
+  <const S extends TypeGuardShape>(shape: S): PluginGuard<InferShape<S>, Plugins>;
+  <const S extends TypeGuardShape>(name: string, shape: S): PluginGuard<InferShape<S>, Plugins>;
+  <T>(parser: Parser<T>, options: PluginOpts<Plugins>): PluginGuard<T, Plugins>;
+  <T>(name: string, parser: Parser<T>, options: PluginOpts<Plugins>): PluginGuard<T, Plugins>;
+  <const S extends TypeGuardShape>(shape: S, options: PluginOpts<Plugins>): PluginGuard<InferShape<S>, Plugins>;
+  <const S extends TypeGuardShape>(name: string, shape: S, options: PluginOpts<Plugins>): PluginGuard<InferShape<S>, Plugins>;
+}

--- a/packages/guardis/src/plugin.ts
+++ b/packages/guardis/src/plugin.ts
@@ -22,6 +22,7 @@ export interface GuardPlugin<TId extends string, TData, TOptions = void> {
   ): { args: Parser | TypeGuardShape; data: TData };
 }
 
+/** Internal shorthand exported for cross-module use in guard.ts. */
 // deno-lint-ignore no-explicit-any
 export type AnyPlugin = GuardPlugin<string, any, any>;
 
@@ -52,7 +53,7 @@ type MergePluginOptionsInner<
  * Type for the extended factory function returned by `withPlugins`.
  */
 // deno-lint-ignore no-explicit-any
-export type PluginOpts<Plugins extends readonly AnyPlugin[]> = MergePluginOptions<Plugins> extends infer O ? [keyof O] extends [never] ? void : O : void;
+type PluginOpts<Plugins extends readonly AnyPlugin[]> = MergePluginOptions<Plugins> extends infer O ? [keyof O] extends [never] ? void : O : void;
 
 export type PluginGuard<T, Plugins extends readonly AnyPlugin[]> = TypeGuard<T> & {
   _: TypeGuard<T>["_"] & { plugins: MergePluginData<Plugins> };

--- a/packages/guardis/src/types.ts
+++ b/packages/guardis/src/types.ts
@@ -89,6 +89,8 @@ export type GuardMeta<T> = {
   context: (value: unknown, ctx?: Context) => StandardSchemaV1.Result<T>;
   /** Indicates this guard is an optional variant, used by InferShape to mark properties as optional */
   optional?: true;
+  /** Plugin metadata keyed by plugin ID. Only present on guards created via an extended factory. */
+  plugins?: Record<string, unknown>;
 };
 
 export interface TypeGuard<T1> extends StandardSchemaV1<T1> {


### PR DESCRIPTION
## Summary

- Adds `createTypeGuard.withPlugins(...plugins)` that returns an extended factory function
- Plugins enrich guards with typed metadata at creation time (no validation-path impact)
- Supports multi-plugin composition, shape transformation via `init`, and duplicate ID detection
- Plugin data stored in `_.plugins[pluginId]` with full type inference

## Design

Plugins define an `id` and an `init` hook. The `init` receives the guard's name, parser/shape args, and plugin-specific options, returning `{ args, data }` — the potentially transformed args for guard creation and the metadata to store. Multiple plugins compose left-to-right.

```typescript
const descPlugin: GuardPlugin<"desc", Record<string, string>, { description: string }> = {
  id: "desc",
  init(name, args, options) {
    return { args, data: { root: options.description } };
  },
};

const create = createTypeGuard.withPlugins(descPlugin);
const isUser = create("User", { name: isString }, { description: "A user" });
isUser._.plugins.desc // => { root: "A user" }
```

## Test plan

- [x] Type-level tests for GuardPlugin, MergePluginData, MergePluginOptions inference
- [x] Single plugin: parser, shape, named variants, options forwarding, standard guard properties preserved
- [x] Multi-plugin: both data slots populated, duplicate ID throws TypeError
- [x] Shape transformation: enriched shape normalization, chained transforms, parser passthrough
- [x] All 79 existing tests pass (705 steps, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)