### PR TITLE
Add .brand() method to TypeGuard

### DIFF
--- a/packages/guardis/src/brand.test.ts
+++ b/packages/guardis/src/brand.test.ts
@@ -471,3 +471,64 @@ Deno.test("RemoveBrand - compile-time type stripping", () => {
   assertType<Equals<RemoveBrand<Brand<number, "X">>, number>>();
   assertType<Equals<RemoveBrand<Brand<{ a: string }, "X">>, { a: string }>>();
 });
+
+// === .brand() method tests ===
+
+Deno.test(".brand() method", async (t) => {
+  await t.step("brands a primitive guard", () => {
+    const isUserId = isString.brand("UserId");
+
+    assert(isUserId("hello"));
+    assertFalse(isUserId(42));
+
+    // Type-level: _TYPE is Brand<string, "UserId">
+    assertType<Equals<typeof isUserId._TYPE, Brand<string, "UserId">>>();
+  });
+
+  await t.step("brands a number guard", () => {
+    const isAge = isNumber.brand("Age");
+
+    assert(isAge(25));
+    assertFalse(isAge("25"));
+
+    assertType<Equals<typeof isAge._TYPE, Brand<number, "Age">>>();
+  });
+
+  await t.step("brands a shape guard", () => {
+    const isUser = createTypeGuard({ name: isString, age: isNumber }).brand("User");
+
+    assert(isUser({ name: "Alice", age: 30 }));
+    assertFalse(isUser({ name: "Alice" }));
+
+    assertType<
+      Equals<typeof isUser._TYPE, Brand<{ name: string; age: number }, "User">>
+    >();
+  });
+
+  await t.step("preserves full guard API", () => {
+    const isUserId = isString.brand("UserId");
+
+    // .strict() works
+    isUserId.strict("hello");
+    assertThrows(() => isUserId.strict(42));
+
+    // .validate() works
+    const valid = isUserId.validate("hello");
+    assert("value" in valid);
+
+    const invalid = isUserId.validate(42);
+    assert("issues" in invalid);
+
+    // .optional works
+    assert(isUserId.optional(undefined));
+    assert(isUserId.optional("hello"));
+  });
+
+  await t.step("branded guard is the same object (zero runtime cost)", () => {
+    const base = isString;
+    const branded = base.brand("Label");
+    // Same validation function — brand is purely type-level
+    assert(base("test") === branded("test"));
+    assert(base(42) === branded(42));
+  });
+});

--- a/packages/guardis/src/brand.ts
+++ b/packages/guardis/src/brand.ts
@@ -1,9 +1,6 @@
 import { createTypeGuard } from "./guard.ts";
 import type { Brand, InferShape, Parser, TypeGuard, TypeGuardShape } from "./types.ts";
 
-// Re-export Brand from types.ts for backward compatibility
-export type { Brand } from "./types.ts";
-
 /**
  * Removes the property with the key `brand` from the given type `T`.
  */

--- a/packages/guardis/src/brand.ts
+++ b/packages/guardis/src/brand.ts
@@ -1,11 +1,8 @@
 import { createTypeGuard } from "./guard.ts";
-import type { InferShape, Parser, TypeGuard, TypeGuardShape } from "./types.ts";
+import type { Brand, InferShape, Parser, TypeGuard, TypeGuardShape } from "./types.ts";
 
-/**
- * Creates a nominal type by intersecting a base type `T` with a unique brand `B`.
- * This helps distinguish between types that are structurally identical but conceptually different.
- */
-export type Brand<T, B extends string> = T & { readonly __brand: B };
+// Re-export Brand from types.ts for backward compatibility
+export type { Brand } from "./types.ts";
 
 /**
  * Removes the property with the key `brand` from the given type `T`.

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -741,6 +741,9 @@ export function createTypeGuard<T1>(
   // StandardSchemaV1 compatibility - uses context-aware validation for path tracking
   callback.validate = (value: unknown) => context(value, createContext());
 
+  // Branding: returns the same guard retyped as Brand<T, B>. Zero runtime cost.
+  callback.brand = () => callback;
+
   callback["~standard"] = {
     version: 1,
     vendor: "guardis",

--- a/packages/guardis/src/types.ts
+++ b/packages/guardis/src/types.ts
@@ -2,6 +2,12 @@ import type { StandardSchemaV1 } from "../specs/standard-schema-spec.v1.ts";
 import type { exact, includes, tupleHas } from "./utilities.ts";
 
 /**
+ * Creates a nominal type by intersecting a base type `T` with a unique brand `B`.
+ * This helps distinguish between types that are structurally identical but conceptually different.
+ */
+export type Brand<T, B extends string> = T & { readonly __brand: B };
+
+/**
  * Context for tracking validation paths and collecting issues during validation.
  * Only present during `validate()` calls, not during regular type guard checks.
  *
@@ -157,6 +163,21 @@ export interface TypeGuard<T1> extends StandardSchemaV1<T1> {
    * @returns
    */
   validate: (value: unknown) => StandardSchemaV1.Result<T1>;
+
+  /**
+   * Returns the same guard retyped as a branded type. No runtime cost — the
+   * guard's validation logic is unchanged, only the TypeScript type narrows
+   * from `T` to `Brand<T, B>`.
+   *
+   * @example
+   * ```typescript
+   * const isUserId = isString.min(1).brand("UserId");
+   * type UserId = typeof isUserId._TYPE; // string & { readonly __brand: "UserId" }
+   *
+   * const isPositiveInt = isInt.gt(0).brand("PositiveInt");
+   * ```
+   */
+  brand<B extends string>(label: B): TypeGuard<Brand<T1, B>>;
 
   /**
    * Extends the current type guard with an additional parser, building upon


### PR DESCRIPTION
## Summary

Every TypeGuard now has a `.brand("Label")` method that returns the same guard retyped as `TypeGuard<Brand<T, B>>`. Zero runtime cost — the validation logic is unchanged, only the TypeScript type narrows.

```ts
const isUserId = isString.min(1).brand("UserId");
type UserId = typeof isUserId._TYPE; // string & { readonly __brand: "UserId" }

const isPositiveInt = isInt.gt(0).brand("PositiveInt");
// Works with any guard, any chain result
```

This replaces the ceremony of `createBrandedTypeGuard` + manual parser extraction for most branding use cases.

## Changes

- Add `Brand<T, B>` type to `types.ts` (moved from `brand.ts` to avoid circular imports)
- Add `.brand<B>(label: B): TypeGuard<Brand<T, B>>` to the `TypeGuard` interface
- Implement in `createTypeGuard` as `callback.brand = () => callback` (pure type-level cast)
- Re-export `Brand` from `brand.ts` for backward compatibility
- Tests with `assertType<Equals<>>` verifying type inference on primitives, numbers, and shapes

## Test plan

- [x] All 76 existing + new tests pass (683 steps)
- [x] Compile-time `assertType<Equals<>>` verifies `_TYPE` resolves to `Brand<T, B>`
- [x] `.strict()`, `.validate()`, `.optional` all work on branded guards
- [x] Backward compatible — `Brand` type still importable from `brand.ts`