### PR TITLE
Guardis 0.7.3

### DIFF
--- a/packages/guardis/deno.json
+++ b/packages/guardis/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@spudlabs/guardis",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "license": "MIT",
   "description": "Guardis is a modular library of type guards, built to be easy to use and extend.",
   "exports": {

--- a/packages/guardis/mod.ts
+++ b/packages/guardis/mod.ts
@@ -44,4 +44,5 @@ export const Is = {
   Tuple: g.isTuple,
   Date: g.isDate,
   Exactly: g.isExactly,
+  Enum: g.isEnum,
 } as const;

--- a/packages/guardis/mod.ts
+++ b/packages/guardis/mod.ts
@@ -25,6 +25,7 @@ export const Is = {
   Boolean: g.isBoolean,
   String: g.isString,
   Number: g.isNumber,
+  Int: g.isInt,
   Binary: g.isBinary,
   Numeric: g.isNumeric,
   Symbol: g.isSymbol,

--- a/packages/guardis/src/brand.test.ts
+++ b/packages/guardis/src/brand.test.ts
@@ -1,9 +1,9 @@
 import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
-import { type Brand, createBrandedTypeGuard, type RemoveBrand } from "./brand.ts";
+import { createBrandedTypeGuard, type RemoveBrand } from "./brand.ts";
 import { createTypeGuard, isNumber, isObject, isString } from "./guard.ts";
 import { hasMeta, hasName } from "./introspect.ts";
-import type { TypeGuard } from "./types.ts";
-import { type Equals, assertType } from "./test-utils.ts";
+import type { Brand, TypeGuard } from "./types.ts";
+import { assertType, type Equals } from "./test-utils.ts";
 
 // === Branded primitive types ===
 

--- a/packages/guardis/src/brand.test.ts
+++ b/packages/guardis/src/brand.test.ts
@@ -471,3 +471,64 @@ Deno.test("RemoveBrand - compile-time type stripping", () => {
   assertType<Equals<RemoveBrand<Brand<number, "X">>, number>>();
   assertType<Equals<RemoveBrand<Brand<{ a: string }, "X">>, { a: string }>>();
 });
+
+// === .brand() method tests ===
+
+Deno.test(".brand() method", async (t) => {
+  await t.step("brands a primitive guard", () => {
+    const isUserId = isString.brand("UserId");
+
+    assert(isUserId("hello"));
+    assertFalse(isUserId(42));
+
+    // Type-level: _TYPE is Brand<string, "UserId">
+    assertType<Equals<typeof isUserId._TYPE, Brand<string, "UserId">>>();
+  });
+
+  await t.step("brands a number guard", () => {
+    const isAge = isNumber.brand("Age");
+
+    assert(isAge(25));
+    assertFalse(isAge("25"));
+
+    assertType<Equals<typeof isAge._TYPE, Brand<number, "Age">>>();
+  });
+
+  await t.step("brands a shape guard", () => {
+    const isUser = createTypeGuard({ name: isString, age: isNumber }).brand("User");
+
+    assert(isUser({ name: "Alice", age: 30 }));
+    assertFalse(isUser({ name: "Alice" }));
+
+    assertType<
+      Equals<typeof isUser._TYPE, Brand<{ name: string; age: number }, "User">>
+    >();
+  });
+
+  await t.step("preserves full guard API", () => {
+    const isUserId = isString.brand("UserId");
+
+    // .strict() works
+    isUserId.strict("hello");
+    assertThrows(() => isUserId.strict(42));
+
+    // .validate() works
+    const valid = isUserId.validate("hello");
+    assert("value" in valid);
+
+    const invalid = isUserId.validate(42);
+    assert("issues" in invalid);
+
+    // .optional works
+    assert(isUserId.optional(undefined));
+    assert(isUserId.optional("hello"));
+  });
+
+  await t.step("branded guard is the same object (zero runtime cost)", () => {
+    const base = isString;
+    const branded = base.brand("Label");
+    // Same validation function — brand is purely type-level
+    assert(base("test") === branded("test"));
+    assert(base(42) === branded(42));
+  });
+});

--- a/packages/guardis/src/brand.ts
+++ b/packages/guardis/src/brand.ts
@@ -1,9 +1,6 @@
 import { createTypeGuard } from "./guard.ts";
 import type { Brand, InferShape, Parser, TypeGuard, TypeGuardShape } from "./types.ts";
 
-// Re-export Brand from types.ts for backward compatibility
-export type { Brand } from "./types.ts";
-
 /**
  * Removes the property with the key `brand` from the given type `T`.
  */

--- a/packages/guardis/src/brand.ts
+++ b/packages/guardis/src/brand.ts
@@ -1,11 +1,8 @@
 import { createTypeGuard } from "./guard.ts";
-import type { InferShape, Parser, TypeGuard, TypeGuardShape } from "./types.ts";
+import type { Brand, InferShape, Parser, TypeGuard, TypeGuardShape } from "./types.ts";
 
-/**
- * Creates a nominal type by intersecting a base type `T` with a unique brand `B`.
- * This helps distinguish between types that are structurally identical but conceptually different.
- */
-export type Brand<T, B extends string> = T & { readonly __brand: B };
+// Re-export Brand from types.ts for backward compatibility
+export type { Brand } from "./types.ts";
 
 /**
  * Removes the property with the key `brand` from the given type `T`.

--- a/packages/guardis/src/guard.test.ts
+++ b/packages/guardis/src/guard.test.ts
@@ -22,6 +22,7 @@ import {
   isPropertyKey,
   isString,
   isSymbol,
+  isEnum,
   isTuple,
   isUndefined,
 } from "./guard.ts";
@@ -5646,5 +5647,81 @@ Deno.test("createTypeGuard with verified shape (explicit type parameter)", async
     assert(isPositive(5));
     assertFalse(isPositive(-1));
     assertType<Equals<typeof isPositive._TYPE, number>>();
+  });
+});
+
+Deno.test("isEnum", async (t) => {
+  // Define test enums
+  enum Color {
+    Red = "red",
+    Green = "green",
+    Blue = "blue",
+  }
+  enum Direction {
+    Up = 0,
+    Down = 1,
+    Left = 2,
+    Right = 3,
+  }
+  enum Mixed {
+    Name = "alice",
+    Age = 30,
+  }
+
+  const isColor = isEnum(Color);
+  const isDirection = isEnum(Direction);
+
+  await t.step("validates string enum members", () => {
+    assert(isColor("red"));
+    assert(isColor("green"));
+    assert(isColor("blue"));
+  });
+
+  await t.step("rejects non-members of string enum", () => {
+    assertFalse(isColor("yellow"));
+    assertFalse(isColor(""));
+    assertFalse(isColor(42));
+  });
+
+  await t.step("validates numeric enum members", () => {
+    assert(isDirection(0));
+    assert(isDirection(1));
+    assert(isDirection(3));
+  });
+
+  await t.step("rejects non-members of numeric enum", () => {
+    assertFalse(isDirection(4));
+    assertFalse(isDirection(-1));
+    // Reverse mapping keys should NOT be valid
+    assertFalse(isDirection("Up"));
+    assertFalse(isDirection("Down"));
+  });
+
+  await t.step("handles mixed enum", () => {
+    const isMixed = isEnum(Mixed);
+    assert(isMixed("alice"));
+    assert(isMixed(30));
+    assertFalse(isMixed("bob"));
+    assertFalse(isMixed(31));
+  });
+
+  await t.step("strict mode throws on non-member", () => {
+    assertThrows(() => isColor.strict("yellow"));
+  });
+
+  await t.step("validate mode returns issues", () => {
+    const result = isColor.validate("yellow");
+    assert("issues" in result && result.issues);
+  });
+
+  await t.step("optional accepts undefined", () => {
+    assert(isColor.optional(undefined));
+    assert(isColor.optional("red"));
+  });
+
+  await t.step("works in shapes", () => {
+    const isPayload = createTypeGuard({ color: isColor });
+    assert(isPayload({ color: "red" }));
+    assertFalse(isPayload({ color: "yellow" }));
   });
 });

--- a/packages/guardis/src/guard.test.ts
+++ b/packages/guardis/src/guard.test.ts
@@ -5648,3 +5648,161 @@ Deno.test("createTypeGuard with verified shape (explicit type parameter)", async
     assertType<Equals<typeof isPositive._TYPE, number>>();
   });
 });
+
+Deno.test("Parser auto-compilation safety", async (t) => {
+  await t.step("parser with data-dependent property access is not broken by compilation", () => {
+    // This parser accesses v.age directly after has() — the Proxy get trap
+    // must cause compilation bailout so the custom logic is preserved.
+    type Person = { name: string; age: number };
+    const isAdult = createTypeGuard<Person>((v, { has }) => {
+      if (isObject(v) && has(v, "name", isString) && has(v, "age", isNumber)) {
+        if (v.age < 18) return null;
+        return v;
+      }
+      return null;
+    });
+
+    assert(isAdult({ name: "Alice", age: 30 }));
+    assertFalse(isAdult({ name: "Bob", age: 10 }));
+    assertFalse(isAdult({ name: "Charlie" }));
+    assertFalse(isAdult("not an object"));
+  });
+
+  await t.step("parser with Object.keys enumeration is not broken by compilation", () => {
+    // Object.keys triggers ownKeys trap — must bail out.
+    const isStrictObject = createTypeGuard<{ name: string }>((v, { has }) => {
+      if (isObject(v) && has(v, "name", isString)) {
+        if (Object.keys(v).length > 1) return null;
+        return v;
+      }
+      return null;
+    });
+
+    assert(isStrictObject({ name: "Alice" }));
+    assertFalse(isStrictObject({ name: "Alice", extra: true }));
+  });
+
+  await t.step("parser that transforms the value is not broken by compilation", () => {
+    const isNormalized = createTypeGuard<{ name: string; normalized: true }>((v, { has }) => {
+      if (isObject(v) && has(v, "name", isString)) {
+        return { ...v, normalized: true as const };
+      }
+      return null;
+    });
+
+    const result = isNormalized({ name: "Alice" });
+    assert(result);
+    // Validate the transform actually happened
+    const validated = isNormalized.validate({ name: "Alice" });
+    assert("value" in validated);
+    assertEquals(validated.value.normalized, true);
+  });
+
+  await t.step("parser using fail helper is not broken by compilation", () => {
+    const isPositiveAge = createTypeGuard<number>("PositiveAge", (v, { fail }) => {
+      if (typeof v !== "number") return fail("Must be a number");
+      if (v < 0) return fail("Must be positive");
+      return v;
+    });
+
+    assert(isPositiveAge(5));
+    assertFalse(isPositiveAge(-1));
+    assertFalse(isPositiveAge("not a number"));
+  });
+
+  await t.step("parser using includes helper is not broken by compilation", () => {
+    const VALID_ROLES = ["admin", "user", "guest"] as const;
+    const isRole = createTypeGuard<{ role: string }>((v, { has, includes }) => {
+      if (isObject(v) && has(v, "role", isString) && includes(VALID_ROLES, v.role)) {
+        return v;
+      }
+      return null;
+    });
+
+    assert(isRole({ role: "admin" }));
+    assertFalse(isRole({ role: "superadmin" }));
+  });
+
+  await t.step("compilable parser achieves same results as shape", () => {
+    // A standard has-chain parser — should be auto-compiled.
+    type User = { name: string; age: number; active: boolean };
+    const isUserParser = createTypeGuard<User>((v, { has }) => {
+      if (
+        isObject(v) &&
+        has(v, "name", isString) &&
+        has(v, "age", isNumber) &&
+        has(v, "active", isBoolean)
+      ) return v;
+      return null;
+    });
+
+    const isUserShape = createTypeGuard({
+      name: isString,
+      age: isNumber,
+      active: isBoolean,
+    });
+
+    const valid = { name: "Alice", age: 30, active: true };
+    const invalid = { name: 123, age: "thirty", active: "yes" };
+
+    // Boolean path: same results
+    assertEquals(isUserParser(valid), isUserShape(valid));
+    assertEquals(isUserParser(invalid), isUserShape(invalid));
+
+    // Missing field
+    assertFalse(isUserParser({ name: "Alice", age: 30 }));
+    assertFalse(isUserShape({ name: "Alice", age: 30 }));
+
+    // Not an object
+    assertFalse(isUserParser("string"));
+    assertFalse(isUserShape("string"));
+    assertFalse(isUserParser(null));
+    assertFalse(isUserShape(null));
+  });
+
+  await t.step("parser with hasOptional compiles and works", () => {
+    type User = { name: string; age?: number };
+    const isUser = createTypeGuard<User>((v, { has, hasOptional }) => {
+      if (isObject(v) && has(v, "name", isString) && hasOptional(v, "age", isNumber)) {
+        return v;
+      }
+      return null;
+    });
+
+    assert(isUser({ name: "Alice" }));
+    assert(isUser({ name: "Alice", age: 30 }));
+    assertFalse(isUser({ name: "Alice", age: "thirty" }));
+    assertFalse(isUser({}));
+  });
+
+  await t.step("parser with hasNot compiles and works", () => {
+    type PublicUser = { name: string };
+    const isPublicUser = createTypeGuard<PublicUser>((v, { has, hasNot }) => {
+      if (isObject(v) && has(v, "name", isString) && hasNot(v, "password")) {
+        return v;
+      }
+      return null;
+    });
+
+    assert(isPublicUser({ name: "Alice" }));
+    assertFalse(isPublicUser({ name: "Alice", password: "secret" }));
+    assertFalse(isPublicUser({}));
+  });
+
+  await t.step("parser with nested guards compiles and works", () => {
+    type Address = { city: string; zip: string };
+    type Person = { name: string; address: Address };
+    const isAddress = createTypeGuard<Address>((v, { has }) => {
+      if (isObject(v) && has(v, "city", isString) && has(v, "zip", isString)) return v;
+      return null;
+    });
+    const isPerson = createTypeGuard<Person>((v, { has }) => {
+      if (isObject(v) && has(v, "name", isString) && has(v, "address", isAddress)) return v;
+      return null;
+    });
+
+    assert(isPerson({ name: "Alice", address: { city: "NYC", zip: "10001" } }));
+    assertFalse(isPerson({ name: "Alice", address: { city: "NYC" } }));
+    assertFalse(isPerson({ name: "Alice" }));
+  });
+});

--- a/packages/guardis/src/guard.test.ts
+++ b/packages/guardis/src/guard.test.ts
@@ -9,6 +9,7 @@ import {
   isEmpty,
   isExactly,
   isFunction,
+  isInt,
   isIterable,
   isJsonArray,
   isJsonObject,
@@ -5646,5 +5647,63 @@ Deno.test("createTypeGuard with verified shape (explicit type parameter)", async
     assert(isPositive(5));
     assertFalse(isPositive(-1));
     assertType<Equals<typeof isPositive._TYPE, number>>();
+  });
+});
+
+Deno.test("isInt", async (t) => {
+  await t.step("basic functionality", () => {
+    // Valid inputs
+    assert(isInt(42));
+    assert(isInt(-1));
+    assert(isInt(0));
+
+    // Invalid inputs
+    assertFalse(isInt(3.14));
+    assertFalse(isInt(NaN));
+    assertFalse(isInt(Infinity));
+    assertFalse(isInt("42"));
+  });
+
+  await t.step("chaining comparisons", () => {
+    assert(isInt.gt(0).lt(100)(50));
+    assertFalse(isInt.gt(0).lt(100)(0));
+    assertFalse(isInt.gt(0).lt(100)(100));
+  });
+
+  await t.step("strict mode", () => {
+    isInt.strict(42);
+    assertThrows(() => isInt.strict(3.14));
+  });
+
+  await t.step("validate method", () => {
+    assertEquals(isInt.validate(42), { value: 42 });
+    const result = isInt.validate(3.14);
+    assert("issues" in result);
+  });
+
+  await t.step("optional mode", () => {
+    assert(isInt.optional(undefined));
+    assert(isInt.optional(42));
+    assertFalse(isInt.optional(3.14));
+  });
+});
+
+Deno.test("isNumber.finite", async (t) => {
+  await t.step("basic functionality", () => {
+    assert(isNumber.finite(42));
+    assert(isNumber.finite(-3.14));
+
+    assertFalse(isNumber.finite(Infinity));
+    assertFalse(isNumber.finite(-Infinity));
+  });
+
+  await t.step("chaining after finite", () => {
+    assert(isNumber.finite.gte(0)(5));
+    assertFalse(isNumber.finite.gte(0)(-1));
+  });
+
+  await t.step("strict mode", () => {
+    isNumber.finite.strict(42);
+    assertThrows(() => isNumber.finite.strict(Infinity));
   });
 });

--- a/packages/guardis/src/guard.test.ts
+++ b/packages/guardis/src/guard.test.ts
@@ -7,6 +7,7 @@ import {
   isBoolean,
   isDate,
   isEmpty,
+  isEnum,
   isExactly,
   isFunction,
   isIterable,
@@ -22,7 +23,6 @@ import {
   isPropertyKey,
   isString,
   isSymbol,
-  isEnum,
   isTuple,
   isUndefined,
 } from "./guard.ts";
@@ -5279,12 +5279,14 @@ Deno.test("shape optional property inference", async (t) => {
       avatar: isString.optional,
     });
     type Profile = typeof isProfile._TYPE;
-    assertType<Equals<Profile, {
-      name: string;
-      age: number;
-      bio?: string | undefined;
-      avatar?: string | undefined;
-    }>>();
+    assertType<
+      Equals<Profile, {
+        name: string;
+        age: number;
+        bio?: string | undefined;
+        avatar?: string | undefined;
+      }>
+    >();
   });
 
   await t.step("runtime accepts missing optional properties", () => {
@@ -5495,9 +5497,7 @@ Deno.test("array length methods", async (t) => {
   });
 
   await t.step("extend after length method", () => {
-    const guard = isArray.of(isNumber).min(1).extend((v) =>
-      v.every((n) => n > 0) ? v : null
-    );
+    const guard = isArray.of(isNumber).min(1).extend((v) => v.every((n) => n > 0) ? v : null);
     assert(guard([1, 2, 3]));
     assertFalse(guard([]));
     assertFalse(guard([-1, 2]));
@@ -5723,5 +5723,10 @@ Deno.test("isEnum", async (t) => {
     const isPayload = createTypeGuard({ color: isColor });
     assert(isPayload({ color: "red" }));
     assertFalse(isPayload({ color: "yellow" }));
+  });
+
+  await t.step("inferred type matches the original enum", () => {
+    assertType<Equals<typeof isColor._TYPE, typeof Color[keyof typeof Color]>>();
+    assertType<Equals<typeof isDirection._TYPE, typeof Direction[keyof typeof Direction]>>();
   });
 });

--- a/packages/guardis/src/guard.test.ts
+++ b/packages/guardis/src/guard.test.ts
@@ -5522,6 +5522,54 @@ Deno.test("array length methods", async (t) => {
   });
 });
 
+Deno.test("string length methods", async (t) => {
+  await t.step("min", () => {
+    assert(isString.min(1)("hello"));
+    assertFalse(isString.min(1)(""));
+  });
+
+  await t.step("max", () => {
+    assert(isString.max(5)("hi"));
+    assertFalse(isString.max(3)("toolong"));
+  });
+
+  await t.step("ofLength", () => {
+    assert(isString.ofLength(3)("abc"));
+    assertFalse(isString.ofLength(3)("ab"));
+  });
+
+  await t.step("range", () => {
+    assert(isString.range(1, 10)("hello"));
+    assertFalse(isString.range(1, 10)(""));
+  });
+
+  await t.step("chaining min and max", () => {
+    assert(isString.min(1).max(255)("hello"));
+    assertFalse(isString.min(1).max(255)(""));
+  });
+
+  await t.step("edge case: ofLength(0)", () => {
+    assert(isString.ofLength(0)(""));
+  });
+
+  await t.step("strict throws on invalid", () => {
+    assertThrows(() => isString.min(1).strict(""));
+  });
+
+  await t.step("validate returns issues on invalid", () => {
+    const result = isString.min(1).validate("");
+    assert(!("value" in result));
+    assert("issues" in result);
+  });
+
+  await t.step("non-string input rejected", () => {
+    assertFalse(isString.min(1)(42));
+    assertFalse(isString.max(5)(null));
+    assertFalse(isString.ofLength(3)(undefined));
+    assertFalse(isString.range(1, 10)(123));
+  });
+});
+
 Deno.test("createTypeGuard with verified shape (explicit type parameter)", async (t) => {
   await t.step("basic typed shape guard validates correctly", () => {
     type User = { id: number; name: string };

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -801,6 +801,11 @@ function withComparisons(guard: TypeGuard<number>): NumberTypeGuard {
   numeric.lt = (n) => withComparisons(guard.extend(`< ${n}`, (v) => v < n ? v : null));
   numeric.lte = (n) => withComparisons(guard.extend(`<= ${n}`, (v) => v <= n ? v : null));
   numeric.eq = (n) => withComparisons(guard.extend(`== ${n}`, (v) => v === n ? v : null));
+  Object.defineProperty(numeric, 'finite', {
+    get: () => withComparisons(guard.extend('finite', (v) => Number.isFinite(v) ? v : null)),
+    enumerable: true,
+    configurable: true,
+  });
   return numeric;
 }
 
@@ -816,6 +821,17 @@ function withComparisons(guard: TypeGuard<number>): NumberTypeGuard {
 export const isNumber: NumberTypeGuard = withComparisons(createTypeGuard(
   "number",
   (t): number | null => typeof t === "number" && !Number.isNaN(t) ? t : null,
+));
+
+/**
+ * Returns true if input is an integer. Rejects NaN, Infinity, and non-integer numbers.
+ *
+ * @param {unknown} t
+ * @return {boolean}
+ */
+export const isInt: NumberTypeGuard = withComparisons(createTypeGuard(
+  "integer",
+  (t): number | null => typeof t === "number" && Number.isInteger(t) ? t : null,
 ));
 
 /**

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -161,7 +161,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 type FieldDescriptor =
   | { kind: "typeGuard"; key: string; guard: TypeGuard<unknown> }
   | { kind: "nested"; key: string; fields: FieldDescriptor[] }
-  | { kind: "typePredicate"; key: string; guard: (value: unknown) => boolean };
+  | { kind: "typePredicate"; key: string; guard: (value: unknown) => boolean }
+  | { kind: "required"; key: string }
+  | { kind: "absent"; key: string };
 
 /**
  * Compiles a TypeGuardShape into a pre-resolved array of field descriptors.
@@ -267,6 +269,30 @@ function validateCompiledField(
         }
         break;
       }
+      case "required": {
+        if (key in obj) {
+          result[key] = obj[key];
+        } else {
+          const message = `Missing required property: ${key}`;
+          if (ctx) {
+            ctx.addIssue(message);
+          } else {
+            localIssues.push({ message, path: [key] });
+          }
+        }
+        break;
+      }
+      case "absent": {
+        if (key in obj) {
+          const message = `Property must not be present: ${key}`;
+          if (ctx) {
+            ctx.addIssue(message);
+          } else {
+            localIssues.push({ message, path: [key] });
+          }
+        }
+        break;
+      }
     }
   } finally {
     if (ctx) ctx.popPath();
@@ -300,6 +326,14 @@ function validateCompiledShapeBoolean(
       }
       case "typePredicate": {
         if (!desc.guard(value[key])) return false;
+        break;
+      }
+      case "required": {
+        if (!(key in value)) return false;
+        break;
+      }
+      case "absent": {
+        if (key in value) return false;
         break;
       }
     }
@@ -517,6 +551,125 @@ const createNotEmptyTypeGuard = <T>(guard: Predicate<T>) => {
  * ```
  */
 
+/**
+ * Classifies a guard into a FieldDescriptor, reusing the same logic as compileShape.
+ */
+function classifyGuard(
+  key: string,
+  guard: ((v: unknown) => boolean) | TypeGuard<unknown>,
+): FieldDescriptor {
+  if (hasContext(guard as Predicate<unknown>)) {
+    return { kind: "typeGuard", key, guard: guard as unknown as TypeGuard<unknown> };
+  }
+  return { kind: "typePredicate", key, guard: guard as (value: unknown) => boolean };
+}
+
+/**
+ * Attempts to auto-compile a parser callback into pre-compiled field descriptors.
+ * Runs the parser once at creation time against a Proxy probe that records
+ * has/hasOptional/hasNot calls. If the parser follows a compilable pattern
+ * (isObject + unconditional has-chain, returning value unchanged), returns
+ * a compiled parser equivalent to shape-based guards. Otherwise returns null
+ * and the caller falls back to the original closure-based parser.
+ */
+function tryCompileParser<T1>(parser: Parser<T1>): Parser<T1> | null {
+  const fields: FieldDescriptor[] = [];
+  let failed = false;
+
+  const probe = new Proxy({} as Record<string, unknown>, {
+    has() {
+      return true;
+    },
+    get() {
+      failed = true;
+      return undefined;
+    },
+    ownKeys() {
+      failed = true;
+      return [];
+    },
+    set() {
+      failed = true;
+      return true;
+    },
+    deleteProperty() {
+      failed = true;
+      return true;
+    },
+  });
+
+  const probeHelpers: HelpersWithContext = {
+    has: ((_t: object, k: PropertyKey, guard?: (v: unknown) => boolean) => {
+      if (failed) return true;
+      if (guard) {
+        fields.push(classifyGuard(String(k), guard));
+      } else {
+        fields.push({ kind: "required", key: String(k) });
+      }
+      return true;
+    }) as HelpersWithContext["has"],
+    hasOptional: ((_t: object, k: PropertyKey, guard?: (v: unknown) => boolean) => {
+      if (failed) return true;
+      if (guard && hasContext(guard as Predicate<unknown>)) {
+        const g = guard as unknown as TypeGuard<unknown>;
+        if (g.optional) {
+          fields.push({ kind: "typeGuard", key: String(k), guard: g.optional as unknown as TypeGuard<unknown> });
+        } else {
+          fields.push(classifyGuard(String(k), guard));
+        }
+      } else if (guard) {
+        fields.push({ kind: "typePredicate", key: String(k), guard: guard as (v: unknown) => boolean });
+      }
+      return true;
+    }) as HelpersWithContext["hasOptional"],
+    hasNot: ((_t: object, k: PropertyKey) => {
+      if (failed) return true;
+      fields.push({ kind: "absent", key: String(k) });
+      return true;
+    }) as HelpersWithContext["hasNot"],
+    tupleHas: (() => {
+      failed = true;
+      return true;
+    }) as unknown as HelpersWithContext["tupleHas"],
+    includes: ((arr: readonly unknown[], val: unknown) => {
+      failed = true;
+      return arr.includes(val);
+    }) as HelpersWithContext["includes"],
+    keyOf: (() => {
+      failed = true;
+      return false;
+    }) as unknown as HelpersWithContext["keyOf"],
+    exact: ((a: unknown, b: unknown) => {
+      failed = true;
+      return a === b;
+    }) as HelpersWithContext["exact"],
+    fail: (() => {
+      failed = true;
+      return null;
+    }) as HelpersWithContext["fail"],
+    _ctx: undefined,
+  };
+
+  try {
+    const result = parser(probe as unknown, probeHelpers);
+    if (result !== probe || failed || fields.length === 0) return null;
+  } catch {
+    return null;
+  }
+
+  // Compilation succeeded — use compiled fields for the boolean fast path,
+  // but fall back to the original parser for the validate path to preserve
+  // exact behavioral parity (original object returned, custom error messages, etc.)
+  return (val: unknown, helpers: HelpersWithContext) => {
+    const ctx = helpers._ctx;
+    if (ctx === undefined) {
+      return validateCompiledShapeBoolean(val, fields) ? (val as T1) : null;
+    }
+    // Validate path: use original parser to preserve exact error messages and return value
+    return parser(val, helpers);
+  };
+}
+
 /** Pre-compiles a shape into a parser that uses cached field descriptors. */
 function compileShapeParser<T1>(shape: TypeGuardShape): Parser<T1> {
   const fields = compileShape(shape);
@@ -615,10 +768,11 @@ export function createTypeGuard<T1>(
   const parserOrShape = args.length === 1 ? args[0] : args[1];
   const name = args.length === 2 ? args[0] as string : undefined;
 
-  // Convert shape to parser, then continue with normal guard creation
+  // Convert shape to parser, or try to auto-compile parser callbacks into
+  // field descriptors for parity with shape-based performance.
   const parser: Parser<T1> = isTypeGuardShape(parserOrShape)
     ? compileShapeParser(parserOrShape)
-    : parserOrShape;
+    : tryCompileParser(parserOrShape) ?? parserOrShape;
 
   /**
    * Internal validation method that accepts a context for path tracking.

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -794,15 +794,15 @@ export const isString: TypeGuard<string> = createTypeGuard(
  * Wraps a TypeGuard<number> with chainable comparison methods (gt, gte, lt, lte, eq).
  * Each method delegates to .extend() and wraps the result for further chaining.
  */
-function withComparisons(guard: TypeGuard<number>): NumberTypeGuard {
-  const numeric = guard as NumberTypeGuard;
+function withComparisons(guard: TypeGuard<number>): TypeGuard<number> & NumberTypeGuard {
+  const numeric = guard as TypeGuard<number> & NumberTypeGuard;
   numeric.gt = (n) => withComparisons(guard.extend(`> ${n}`, (v) => v > n ? v : null));
   numeric.gte = (n) => withComparisons(guard.extend(`>= ${n}`, (v) => v >= n ? v : null));
   numeric.lt = (n) => withComparisons(guard.extend(`< ${n}`, (v) => v < n ? v : null));
   numeric.lte = (n) => withComparisons(guard.extend(`<= ${n}`, (v) => v <= n ? v : null));
-  numeric.eq = (n) => withComparisons(guard.extend(`== ${n}`, (v) => v === n ? v : null));
-  Object.defineProperty(numeric, 'finite', {
-    get: () => withComparisons(guard.extend('finite', (v) => Number.isFinite(v) ? v : null)),
+  numeric.eq = (n) => guard.extend(`== ${n}`, (v) => v === n ? v : null);
+  Object.defineProperty(numeric, "finite", {
+    get: () => withComparisons(guard.extend("finite", (v) => Number.isFinite(v) ? v : null)),
     enumerable: true,
     configurable: true,
   });
@@ -818,7 +818,7 @@ function withComparisons(guard: TypeGuard<number>): NumberTypeGuard {
  * @param {unknown} t
  * @return {boolean}
  */
-export const isNumber: NumberTypeGuard = withComparisons(createTypeGuard(
+export const isNumber: TypeGuard<number> & NumberTypeGuard = withComparisons(createTypeGuard(
   "number",
   (t): number | null => typeof t === "number" && !Number.isNaN(t) ? t : null,
 ));
@@ -829,7 +829,7 @@ export const isNumber: NumberTypeGuard = withComparisons(createTypeGuard(
  * @param {unknown} t
  * @return {boolean}
  */
-export const isInt: NumberTypeGuard = withComparisons(createTypeGuard(
+export const isInt: TypeGuard<number> & NumberTypeGuard = withComparisons(createTypeGuard(
   "integer",
   (t): number | null => typeof t === "number" && Number.isInteger(t) ? t : null,
 ));
@@ -886,7 +886,7 @@ export function isExactly<const T>(expected: T): TypeGuard<T> {
  */
 const NUMERIC_RE = /^-?\d*\.?\d+$/;
 
-export const isNumeric: NumberTypeGuard = withComparisons(createTypeGuard(
+export const isNumeric: TypeGuard<number> & NumberTypeGuard = withComparisons(createTypeGuard(
   "numeric",
   (t): number | null => {
     if (isNumber(t)) return t as number;

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -18,11 +18,12 @@ import type {
   JsonValue,
   NamedParser,
   NumberTypeGuard,
-  StringTypeGuard,
   Parser,
   ParserEntry,
   Predicate,
+  Simplify,
   StrictTypeGuard,
+  StringTypeGuard,
   TupleOfLength,
   TypeGuard,
   TypeGuardShape,
@@ -790,22 +791,24 @@ export const isBoolean: TypeGuard<boolean> = createTypeGuard(
  * Wraps a string TypeGuard with chainable length validation methods.
  * Each method delegates to .extend() and wraps the result for further chaining.
  */
-function withStringMethods(guard: TypeGuard<string>): StringTypeGuard {
-  const str = guard as StringTypeGuard;
-  str.ofLength = (n) => withStringMethods(guard.extend(`length == ${n}`, (v) => v.length === n ? v : null));
-  str.min = (n) => withStringMethods(guard.extend(`length >= ${n}`, (v) => v.length >= n ? v : null));
-  str.max = (n) => withStringMethods(guard.extend(`length <= ${n}`, (v) => v.length <= n ? v : null));
-  str.range = (min, max) =>
-    withStringMethods(
+function withStringMethods(guard: TypeGuard<string>): TypeGuard<string> & StringTypeGuard {
+  return Object.assign(guard, {
+    ofLength: (n: number) => guard.extend(`length == ${n}`, (v) => v.length === n ? v : null),
+    range: (min: number, max: number) =>
       guard.extend(`length ${min}..${max}`, (v) => v.length >= min && v.length <= max ? v : null),
-    );
-  return str;
+    min: (n: number) =>
+      withStringMethods(guard.extend(`length >= ${n}`, (v) => v.length >= n ? v : null)),
+    max: (n: number) =>
+      withStringMethods(guard.extend(`length <= ${n}`, (v) => v.length <= n ? v : null)),
+  }) as TypeGuard<string> & StringTypeGuard;
 }
 
-export const isString: StringTypeGuard = withStringMethods(createTypeGuard(
-  "string",
-  (t): string | null => typeof t === "string" ? t : null,
-));
+export const isString: TypeGuard<string> & Simplify<StringTypeGuard> = withStringMethods(
+  createTypeGuard(
+    "string",
+    (t): string | null => typeof t === "string" ? t : null,
+  ),
+);
 
 /**
  * Wraps a TypeGuard<number> with chainable comparison methods (gt, gte, lt, lte, eq).
@@ -938,7 +941,7 @@ const isNull: TypeGuard<null> = createTypeGuard<null>(
  */
 export const isJsonPrimitive: TypeGuard<JsonPrimitive> = unionOf(
   isBoolean,
-  isString as TypeGuard<string>,
+  isString,
   isNumber,
   isNull,
 );
@@ -959,7 +962,11 @@ export const isObject: TypeGuard<object> = createTypeGuard(
  * @param {unknown} t
  * @return {boolean}
  */
-export const isPropertyKey: TypeGuard<PropertyKey> = unionOf(isString as TypeGuard<string>, isNumber, isSymbol);
+export const isPropertyKey: TypeGuard<PropertyKey> = unionOf(
+  isString as TypeGuard<string>,
+  isNumber,
+  isSymbol,
+);
 
 /**
  * Returns true if input satisfies type object. _BEWARE_ object

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -783,11 +783,6 @@ export const isBoolean: TypeGuard<boolean> = createTypeGuard(
 );
 
 /**
- * Returns true if input satisfies type string.
- * @param {unknown} t
- * @return {boolean}
- */
-/**
  * Wraps a string TypeGuard with chainable length validation methods.
  * Each method delegates to .extend() and wraps the result for further chaining.
  */
@@ -803,6 +798,11 @@ function withStringMethods(guard: TypeGuard<string>): TypeGuard<string> & String
   }) as TypeGuard<string> & StringTypeGuard;
 }
 
+/**
+ * Returns true if input satisfies type string.
+ * @param {unknown} t
+ * @return {boolean}
+ */
 export const isString: TypeGuard<string> & Simplify<StringTypeGuard> = withStringMethods(
   createTypeGuard(
     "string",

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -741,6 +741,9 @@ export function createTypeGuard<T1>(
   // StandardSchemaV1 compatibility - uses context-aware validation for path tracking
   callback.validate = (value: unknown) => context(value, createContext());
 
+  // Branding: returns the same guard retyped as Brand<T, B>. Zero runtime cost.
+  callback.brand = () => callback;
+
   callback["~standard"] = {
     version: 1,
     vendor: "guardis",

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -535,25 +535,6 @@ const createNotEmptyTypeGuard = <T>(guard: Predicate<T>) => {
 };
 
 /**
- * Creates a type guard from a parser function.
- *
- * The parser should perform whatever checks are necessary to safely establish
- * that the input is of the specified type.
- *
- * Injects the `has` utility method as the second argument of any parser, as
- * a convenience to check if a property exists in an object.
- *
- * @param parser A function that returns the value if valid, or null if invalid.
- * @returns A type guard function with utility methods.
- *
- * @example
- * ```typescript
- * const parseString = (val: unknown): string | null => typeof val === 'string' ? val : null;
- * const isString = createTypeGuard(parseString);
- * ```
- */
-
-/**
  * Classifies a guard into a FieldDescriptor, reusing the same logic as compileShape.
  */
 function classifyGuard(
@@ -561,8 +542,9 @@ function classifyGuard(
   guard: ((v: unknown) => boolean) | TypeGuard<unknown>,
 ): FieldDescriptor {
   if (hasContext(guard as Predicate<unknown>)) {
-    return { kind: "typeGuard", key, guard: guard as unknown as TypeGuard<unknown> };
+    return { kind: "typeGuard", key, guard: guard as TypeGuard<unknown> };
   }
+
   return { kind: "typePredicate", key, guard: guard as (value: unknown) => boolean };
 }
 
@@ -603,6 +585,7 @@ function tryCompileParser<T1>(parser: Parser<T1>): Parser<T1> | null {
   const probeHelpers: HelpersWithContext = {
     has: ((_t: object, k: PropertyKey, guard?: (v: unknown) => boolean) => {
       if (failed) return true;
+
       if (guard) {
         fields.push(classifyGuard(String(k), guard));
       } else {
@@ -612,20 +595,26 @@ function tryCompileParser<T1>(parser: Parser<T1>): Parser<T1> | null {
     }) as HelpersWithContext["has"],
     hasOptional: ((_t: object, k: PropertyKey, guard?: (v: unknown) => boolean) => {
       if (failed) return true;
+
       if (guard && hasContext(guard as Predicate<unknown>)) {
-        const g = guard as unknown as TypeGuard<unknown>;
+        const g = guard as TypeGuard<unknown>;
         if (g.optional) {
-          fields.push({ kind: "typeGuard", key: String(k), guard: g.optional as unknown as TypeGuard<unknown> });
+          fields.push({
+            kind: "typeGuard",
+            key: String(k),
+            guard: g.optional as TypeGuard<unknown>,
+          });
         } else {
           fields.push(classifyGuard(String(k), guard));
         }
       } else if (guard) {
-        fields.push({ kind: "typePredicate", key: String(k), guard: guard as (v: unknown) => boolean });
+        fields.push({ kind: "typePredicate", key: String(k), guard });
       }
       return true;
     }) as HelpersWithContext["hasOptional"],
     hasNot: ((_t: object, k: PropertyKey) => {
       if (failed) return true;
+
       fields.push({ kind: "absent", key: String(k) });
       return true;
     }) as HelpersWithContext["hasNot"],
@@ -663,10 +652,10 @@ function tryCompileParser<T1>(parser: Parser<T1>): Parser<T1> | null {
   // but fall back to the original parser for the validate path to preserve
   // exact behavioral parity (original object returned, custom error messages, etc.)
   return (val: unknown, helpers: HelpersWithContext) => {
-    const ctx = helpers._ctx;
-    if (ctx === undefined) {
+    if (helpers._ctx === undefined) {
       return validateCompiledShapeBoolean(val, fields) ? (val as T1) : null;
     }
+
     // Validate path: use original parser to preserve exact error messages and return value
     return parser(val, helpers);
   };
@@ -685,10 +674,29 @@ function compileShapeParser<T1>(shape: TypeGuardShape): Parser<T1> {
     }
     // Slow path: caller wants issue tracking via .validate() or nested validation.
     const result = validateCompiledShape(val, fields, ctx);
+
     return "value" in result ? result.value as T1 : null;
   };
 }
 
+/**
+ * Creates a type guard from a parser function.
+ *
+ * The parser should perform whatever checks are necessary to safely establish
+ * that the input is of the specified type.
+ *
+ * Injects the `has` utility method as the second argument of any parser, as
+ * a convenience to check if a property exists in an object.
+ *
+ * @param parser A function that returns the value if valid, or null if invalid.
+ * @returns A type guard function with utility methods.
+ *
+ * @example
+ * ```typescript
+ * const parseString = (val: unknown): string | null => typeof val === 'string' ? val : null;
+ * const isString = createTypeGuard(parseString);
+ * ```
+ */
 export function createTypeGuard<T1>(parser: Parser<T1>): TypeGuard<T1>;
 /**
  * Creates a type guard from a parser function with a custom type name.
@@ -876,11 +884,12 @@ export function createTypeGuard<T1>(
    */
   callback.notEmpty = createNotEmptyTypeGuard(callback);
 
-  type OptionalTypeGuard = ReturnType<typeof createOptionalTypeGuard<T1>> & {
-    notEmpty: typeof callback.notEmpty.optional;
-  };
+  const optional = createOptionalTypeGuard(callback, parser, context) as
+    & ReturnType<typeof createOptionalTypeGuard<T1>>
+    & {
+      notEmpty: typeof callback.notEmpty.optional;
+    };
 
-  const optional = createOptionalTypeGuard(callback, parser, context) as OptionalTypeGuard;
   optional.notEmpty = callback.notEmpty.optional;
   callback.optional = optional;
 

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -18,6 +18,7 @@ import type {
   JsonValue,
   NamedParser,
   NumberTypeGuard,
+  StringTypeGuard,
   Parser,
   ParserEntry,
   Predicate,
@@ -785,10 +786,26 @@ export const isBoolean: TypeGuard<boolean> = createTypeGuard(
  * @param {unknown} t
  * @return {boolean}
  */
-export const isString: TypeGuard<string> = createTypeGuard(
+/**
+ * Wraps a string TypeGuard with chainable length validation methods.
+ * Each method delegates to .extend() and wraps the result for further chaining.
+ */
+function withStringMethods(guard: TypeGuard<string>): StringTypeGuard {
+  const str = guard as StringTypeGuard;
+  str.ofLength = (n) => withStringMethods(guard.extend(`length == ${n}`, (v) => v.length === n ? v : null));
+  str.min = (n) => withStringMethods(guard.extend(`length >= ${n}`, (v) => v.length >= n ? v : null));
+  str.max = (n) => withStringMethods(guard.extend(`length <= ${n}`, (v) => v.length <= n ? v : null));
+  str.range = (min, max) =>
+    withStringMethods(
+      guard.extend(`length ${min}..${max}`, (v) => v.length >= min && v.length <= max ? v : null),
+    );
+  return str;
+}
+
+export const isString: StringTypeGuard = withStringMethods(createTypeGuard(
   "string",
   (t): string | null => typeof t === "string" ? t : null,
-);
+));
 
 /**
  * Wraps a TypeGuard<number> with chainable comparison methods (gt, gte, lt, lte, eq).
@@ -921,7 +938,7 @@ const isNull: TypeGuard<null> = createTypeGuard<null>(
  */
 export const isJsonPrimitive: TypeGuard<JsonPrimitive> = unionOf(
   isBoolean,
-  isString,
+  isString as TypeGuard<string>,
   isNumber,
   isNull,
 );
@@ -942,7 +959,7 @@ export const isObject: TypeGuard<object> = createTypeGuard(
  * @param {unknown} t
  * @return {boolean}
  */
-export const isPropertyKey: TypeGuard<PropertyKey> = unionOf(isString, isNumber, isSymbol);
+export const isPropertyKey: TypeGuard<PropertyKey> = unionOf(isString as TypeGuard<string>, isNumber, isSymbol);
 
 /**
  * Returns true if input satisfies type object. _BEWARE_ object

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -1271,23 +1271,36 @@ isTuple.optional = isTupleOptional;
 /**
  * Creates a type guard from a TypeScript enum object.
  * Validates that a value is a member of the enum.
- * Handles both string and numeric enums (filters reverse mappings for numeric enums).
+ *
+ * Handles both string and numeric enums. TypeScript compiles numeric enums
+ * with reverse mappings — for `enum Dir { Up = 0, Down = 1 }`, the compiled
+ * object is `{ Up: 0, Down: 1, 0: "Up", 1: "Down" }`. The stringified-number
+ * keys (`"0"`, `"1"`) are the reverse mappings and must be filtered out so
+ * that only the real enum values (`0`, `1`) are treated as valid members.
+ * String enums (`enum Color { Red = "red" }`) produce no reverse mappings,
+ * so the filter is a no-op for them.
+ *
+ * Note: TypeScript does not support exact type-level equality checks for enum
+ * types. The inferred `_TYPE` is the enum's value union (e.g. `Color.Red |
+ * Color.Green | Color.Blue`) rather than the branded `Color` type itself.
+ * Both are mutually assignable — `const c: Color = x` compiles after narrowing
+ * — but they are not identical under strict type-equality checks like
+ * `Equals<A, B>`. This is a known TypeScript limitation, not a Guardis bug.
+ * See: https://github.com/microsoft/TypeScript/issues/49497
  */
-export function isEnum<T extends Record<string, string | number>>(
+export function isEnum<const T extends Record<string, string | number>>(
   enumObj: T,
 ): TypeGuard<T[keyof T]> {
-  // Filter out numeric enum reverse mappings.
-  // For numeric enums, Object.keys includes both "Name" and "0" (the reverse mapping).
-  // We keep only entries where the key is not a stringified number.
+  // Keep only entries whose key is not a stringified number (filters reverse mappings).
   const values = Object.entries(enumObj)
     .filter(([key]) => isNaN(Number(key)))
     .map(([, value]) => value);
-  const memberSet = new Set<string | number>(values);
+  const memberSet = new Set(values);
   const name = `enum(${values.join(" | ")})`;
 
   return createTypeGuard(
     name,
-    (t): T[keyof T] | null => memberSet.has(t as string | number) ? t as T[keyof T] : null,
+    (t) => memberSet.has(t as T[keyof T]) ? t as T[keyof T] : null,
   );
 }
 

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -1268,4 +1268,27 @@ isTupleOptional.assert = isTupleOptional.strict;
  */
 isTuple.optional = isTupleOptional;
 
+/**
+ * Creates a type guard from a TypeScript enum object.
+ * Validates that a value is a member of the enum.
+ * Handles both string and numeric enums (filters reverse mappings for numeric enums).
+ */
+export function isEnum<T extends Record<string, string | number>>(
+  enumObj: T,
+): TypeGuard<T[keyof T]> {
+  // Filter out numeric enum reverse mappings.
+  // For numeric enums, Object.keys includes both "Name" and "0" (the reverse mapping).
+  // We keep only entries where the key is not a stringified number.
+  const values = Object.entries(enumObj)
+    .filter(([key]) => isNaN(Number(key)))
+    .map(([, value]) => value);
+  const memberSet = new Set<string | number>(values);
+  const name = `enum(${values.join(" | ")})`;
+
+  return createTypeGuard(
+    name,
+    (t): T[keyof T] | null => memberSet.has(t as string | number) ? t as T[keyof T] : null,
+  );
+}
+
 export { isEmpty, isIterable, isNil, isNull, isTuple };

--- a/packages/guardis/src/types.ts
+++ b/packages/guardis/src/types.ts
@@ -341,6 +341,18 @@ export interface NumberTypeGuard extends TypeGuard<number> {
   eq(target: number): NumberTypeGuard;
 }
 
+/** A string type guard with chainable length validation methods */
+export interface StringTypeGuard extends TypeGuard<string> {
+  /** Checks string has exactly this length */
+  ofLength(length: number): StringTypeGuard;
+  /** Checks string length >= min */
+  min(length: number): StringTypeGuard;
+  /** Checks string length <= max */
+  max(length: number): StringTypeGuard;
+  /** Checks string length is between min and max (inclusive) */
+  range(min: number, max: number): StringTypeGuard;
+}
+
 /** An array type guard with chainable length validation methods */
 export interface ArrayTypeGuard<T = unknown> extends TypeGuard<T[]> {
   /** Returns a typed array guard preserving length methods */

--- a/packages/guardis/src/types.ts
+++ b/packages/guardis/src/types.ts
@@ -2,6 +2,12 @@ import type { StandardSchemaV1 } from "../specs/standard-schema-spec.v1.ts";
 import type { exact, includes, tupleHas } from "./utilities.ts";
 
 /**
+ * Creates a nominal type by intersecting a base type `T` with a unique brand `B`.
+ * This helps distinguish between types that are structurally identical but conceptually different.
+ */
+export type Brand<T, B extends string> = T & { readonly __brand: B };
+
+/**
  * Context for tracking validation paths and collecting issues during validation.
  * Only present during `validate()` calls, not during regular type guard checks.
  *
@@ -157,6 +163,21 @@ export interface TypeGuard<T1> extends StandardSchemaV1<T1> {
    * @returns
    */
   validate: (value: unknown) => StandardSchemaV1.Result<T1>;
+
+  /**
+   * Returns the same guard retyped as a branded type. No runtime cost — the
+   * guard's validation logic is unchanged, only the TypeScript type narrows
+   * from `T` to `Brand<T, B>`.
+   *
+   * @example
+   * ```typescript
+   * const isUserId = isString.min(1).brand("UserId");
+   * type UserId = typeof isUserId._TYPE; // string & { readonly __brand: "UserId" }
+   *
+   * const isPositiveInt = isInt.gt(0).brand("PositiveInt");
+   * ```
+   */
+  brand<B extends string>(label: B): TypeGuard<Brand<T1, B>>;
 
   /**
    * Extends the current type guard with an additional parser, building upon

--- a/packages/guardis/src/types.ts
+++ b/packages/guardis/src/types.ts
@@ -342,15 +342,15 @@ export interface NumberTypeGuard extends TypeGuard<number> {
 }
 
 /** A string type guard with chainable length validation methods */
-export interface StringTypeGuard extends TypeGuard<string> {
+export interface StringTypeGuard {
   /** Checks string has exactly this length */
-  ofLength(length: number): StringTypeGuard;
+  ofLength(length: number): TypeGuard<string>;
   /** Checks string length >= min */
-  min(length: number): StringTypeGuard;
+  min(length: number): TypeGuard<string> & Omit<StringTypeGuard, "min" | "ofLength" | "range">;
   /** Checks string length <= max */
-  max(length: number): StringTypeGuard;
+  max(length: number): TypeGuard<string> & Omit<StringTypeGuard, "max" | "ofLength" | "range">;
   /** Checks string length is between min and max (inclusive) */
-  range(min: number, max: number): StringTypeGuard;
+  range(min: number, max: number): TypeGuard<string>;
 }
 
 /** An array type guard with chainable length validation methods */
@@ -423,10 +423,15 @@ type IsOptionalGuard<F> = F extends { _: { optional: true } } ? true : false;
 
 /** Recursively infers the TypeScript type from a TypeGuardShape */
 export type InferShape<S extends TypeGuardShape> = Simplify<
-  {
-    -readonly [K in keyof S as IsOptionalGuard<S[K]> extends true ? never : K]: InferShapeField<S[K]>;
-  } & {
-    -readonly [K in keyof S as IsOptionalGuard<S[K]> extends true ? K : never]?: InferShapeField<S[K]>;
+  & {
+    -readonly [K in keyof S as IsOptionalGuard<S[K]> extends true ? never : K]: InferShapeField<
+      S[K]
+    >;
+  }
+  & {
+    -readonly [K in keyof S as IsOptionalGuard<S[K]> extends true ? K : never]?: InferShapeField<
+      S[K]
+    >;
   }
 >;
 
@@ -437,9 +442,8 @@ type ShapeFieldFor<T> =
 
 /** Maps an optional property type to a guard that accepts T | undefined with the optional flag */
 type OptionalShapeFieldFor<T> =
-  | (((value: unknown) => value is (T | undefined)) & { _: { optional: true } })
-  | (T extends Record<string, unknown>
-    ? VerifiedShape<T> & { _: { optional: true } }
+  | (((value: unknown) => value is T | undefined) & { _: { optional: true } })
+  | (T extends Record<string, unknown> ? VerifiedShape<T> & { _: { optional: true } }
     : never);
 
 /**

--- a/packages/guardis/src/types.ts
+++ b/packages/guardis/src/types.ts
@@ -339,6 +339,8 @@ export interface NumberTypeGuard extends TypeGuard<number> {
    * @returns A new NumberTypeGuard with the comparison applied
    */
   eq(target: number): NumberTypeGuard;
+  /** Returns a guard that rejects Infinity and -Infinity. Chainable. */
+  finite: NumberTypeGuard;
 }
 
 /** An array type guard with chainable length validation methods */

--- a/packages/guardis/src/types.ts
+++ b/packages/guardis/src/types.ts
@@ -303,44 +303,40 @@ export type ReplaceTupleIndex<T extends readonly unknown[], X extends number, R>
 };
 
 /** A numeric type guard with chainable comparison methods */
-export interface NumberTypeGuard extends TypeGuard<number> {
-  /**
-   * Returns a guard that checks if the value is greater than the threshold.
-   * Chainable for range validation.
-   * @param threshold The value must be strictly greater than this number
-   * @returns A new NumberTypeGuard with the comparison applied
-   */
-  gt(threshold: number): NumberTypeGuard;
-  /**
-   * Returns a guard that checks if the value is greater than or equal to the threshold.
-   * Chainable for range validation.
-   * @param threshold The value must be greater than or equal to this number
-   * @returns A new NumberTypeGuard with the comparison applied
-   */
-  gte(threshold: number): NumberTypeGuard;
-  /**
-   * Returns a guard that checks if the value is less than the threshold.
-   * Chainable for range validation.
-   * @param threshold The value must be strictly less than this number
-   * @returns A new NumberTypeGuard with the comparison applied
-   */
-  lt(threshold: number): NumberTypeGuard;
-  /**
-   * Returns a guard that checks if the value is less than or equal to the threshold.
-   * Chainable for range validation.
-   * @param threshold The value must be less than or equal to this number
-   * @returns A new NumberTypeGuard with the comparison applied
-   */
-  lte(threshold: number): NumberTypeGuard;
-  /**
-   * Returns a guard that checks if the value is strictly equal to the target.
-   * Chainable for range validation.
-   * @param target The value must be strictly equal to this number
-   * @returns A new NumberTypeGuard with the comparison applied
-   */
-  eq(target: number): NumberTypeGuard;
-  /** Returns a guard that rejects Infinity and -Infinity. Chainable. */
-  finite: NumberTypeGuard;
+/** Number comparison methods available after setting a lower bound */
+type NumberAfterLower = {
+  /** Upper bound (exclusive). Chainable with eq. */
+  lt(threshold: number): TypeGuard<number> & { eq(target: number): TypeGuard<number> };
+  /** Upper bound (inclusive). Chainable with eq. */
+  lte(threshold: number): TypeGuard<number> & { eq(target: number): TypeGuard<number> };
+  /** Exact value (terminal). */
+  eq(target: number): TypeGuard<number>;
+};
+
+/** Number comparison methods available after setting an upper bound */
+type NumberAfterUpper = {
+  /** Lower bound (exclusive). Chainable with eq. */
+  gt(threshold: number): TypeGuard<number> & { eq(target: number): TypeGuard<number> };
+  /** Lower bound (inclusive). Chainable with eq. */
+  gte(threshold: number): TypeGuard<number> & { eq(target: number): TypeGuard<number> };
+  /** Exact value (terminal). */
+  eq(target: number): TypeGuard<number>;
+};
+
+/** Chainable number comparison methods */
+export interface NumberTypeGuard {
+  /** Lower bound (exclusive). Can chain with lt/lte/eq. */
+  gt(threshold: number): TypeGuard<number> & NumberAfterLower;
+  /** Lower bound (inclusive). Can chain with lt/lte/eq. */
+  gte(threshold: number): TypeGuard<number> & NumberAfterLower;
+  /** Upper bound (exclusive). Can chain with gt/gte/eq. */
+  lt(threshold: number): TypeGuard<number> & NumberAfterUpper;
+  /** Upper bound (inclusive). Can chain with gt/gte/eq. */
+  lte(threshold: number): TypeGuard<number> & NumberAfterUpper;
+  /** Exact value (terminal). */
+  eq(target: number): TypeGuard<number>;
+  /** Rejects Infinity and -Infinity. Allows further comparisons. */
+  finite: TypeGuard<number> & Omit<NumberTypeGuard, "finite">;
 }
 
 /** An array type guard with chainable length validation methods */

--- a/packages/guardis/src/types.ts
+++ b/packages/guardis/src/types.ts
@@ -302,37 +302,16 @@ export type ReplaceTupleIndex<T extends readonly unknown[], X extends number, R>
   readonly [K in keyof T]: K extends `${X}` ? R : T[K];
 };
 
-/** A numeric type guard with chainable comparison methods */
-/** Number comparison methods available after setting a lower bound */
-type NumberAfterLower = {
-  /** Upper bound (exclusive). Chainable with eq. */
-  lt(threshold: number): TypeGuard<number> & { eq(target: number): TypeGuard<number> };
-  /** Upper bound (inclusive). Chainable with eq. */
-  lte(threshold: number): TypeGuard<number> & { eq(target: number): TypeGuard<number> };
-  /** Exact value (terminal). */
-  eq(target: number): TypeGuard<number>;
-};
-
-/** Number comparison methods available after setting an upper bound */
-type NumberAfterUpper = {
-  /** Lower bound (exclusive). Chainable with eq. */
-  gt(threshold: number): TypeGuard<number> & { eq(target: number): TypeGuard<number> };
-  /** Lower bound (inclusive). Chainable with eq. */
-  gte(threshold: number): TypeGuard<number> & { eq(target: number): TypeGuard<number> };
-  /** Exact value (terminal). */
-  eq(target: number): TypeGuard<number>;
-};
-
 /** Chainable number comparison methods */
 export interface NumberTypeGuard {
   /** Lower bound (exclusive). Can chain with lt/lte/eq. */
-  gt(threshold: number): TypeGuard<number> & NumberAfterLower;
+  gt(threshold: number): TypeGuard<number> & Omit<NumberTypeGuard, "gt" | "gte" | "eq">;
   /** Lower bound (inclusive). Can chain with lt/lte/eq. */
-  gte(threshold: number): TypeGuard<number> & NumberAfterLower;
+  gte(threshold: number): TypeGuard<number> & Omit<NumberTypeGuard, "gt" | "gte" | "eq">;
   /** Upper bound (exclusive). Can chain with gt/gte/eq. */
-  lt(threshold: number): TypeGuard<number> & NumberAfterUpper;
+  lt(threshold: number): TypeGuard<number> & Omit<NumberTypeGuard, "lt" | "lte" | "eq">;
   /** Upper bound (inclusive). Can chain with gt/gte/eq. */
-  lte(threshold: number): TypeGuard<number> & NumberAfterUpper;
+  lte(threshold: number): TypeGuard<number> & Omit<NumberTypeGuard, "lt" | "lte" | "eq">;
   /** Exact value (terminal). */
   eq(target: number): TypeGuard<number>;
   /** Rejects Infinity and -Infinity. Allows further comparisons. */
@@ -409,10 +388,15 @@ type IsOptionalGuard<F> = F extends { _: { optional: true } } ? true : false;
 
 /** Recursively infers the TypeScript type from a TypeGuardShape */
 export type InferShape<S extends TypeGuardShape> = Simplify<
-  {
-    -readonly [K in keyof S as IsOptionalGuard<S[K]> extends true ? never : K]: InferShapeField<S[K]>;
-  } & {
-    -readonly [K in keyof S as IsOptionalGuard<S[K]> extends true ? K : never]?: InferShapeField<S[K]>;
+  & {
+    -readonly [K in keyof S as IsOptionalGuard<S[K]> extends true ? never : K]: InferShapeField<
+      S[K]
+    >;
+  }
+  & {
+    -readonly [K in keyof S as IsOptionalGuard<S[K]> extends true ? K : never]?: InferShapeField<
+      S[K]
+    >;
   }
 >;
 
@@ -423,9 +407,8 @@ type ShapeFieldFor<T> =
 
 /** Maps an optional property type to a guard that accepts T | undefined with the optional flag */
 type OptionalShapeFieldFor<T> =
-  | (((value: unknown) => value is (T | undefined)) & { _: { optional: true } })
-  | (T extends Record<string, unknown>
-    ? VerifiedShape<T> & { _: { optional: true } }
+  | (((value: unknown) => value is T | undefined) & { _: { optional: true } })
+  | (T extends Record<string, unknown> ? VerifiedShape<T> & { _: { optional: true } }
     : never);
 
 /**

--- a/packages/guardis/src/utilities.test.ts
+++ b/packages/guardis/src/utilities.test.ts
@@ -383,7 +383,10 @@ Deno.test("formatErrorMessage", async (t) => {
   await t.step("handles functions without producing undefined", () => {
     // Bug fix: JSON.stringify(function) returns undefined
     assertEquals(formatErrorMessage(() => {}, "object"), "Expected object. Received: [Function]");
-    assertEquals(formatErrorMessage(function namedFn() {}, "object"), "Expected object. Received: [Function: namedFn]");
+    assertEquals(
+      formatErrorMessage(function namedFn() {}, "object"),
+      "Expected object. Received: [Function: namedFn]",
+    );
   });
 
   await t.step("handles circular references without throwing", () => {
@@ -397,7 +400,10 @@ Deno.test("formatErrorMessage", async (t) => {
 
   await t.step("handles objects with BigInt properties", () => {
     const obj = { id: BigInt(999), name: "test" };
-    assertEquals(formatErrorMessage(obj, "array"), 'Expected array. Received: {"id":"999n","name":"test"}');
+    assertEquals(
+      formatErrorMessage(obj, "array"),
+      'Expected array. Received: {"id":"999n","name":"test"}',
+    );
   });
 
   await t.step("works without name parameter", () => {
@@ -408,7 +414,7 @@ Deno.test("formatErrorMessage", async (t) => {
 
 Deno.test("unionOf", async (t) => {
   await t.step("creates union from multiple guards", () => {
-    const isStringOrNumber = unionOf(isString as TypeGuard<string>, isNumber);
+    const isStringOrNumber = unionOf(isString, isNumber);
 
     assert(isStringOrNumber("hello"));
     assert(isStringOrNumber(42));
@@ -417,14 +423,14 @@ Deno.test("unionOf", async (t) => {
   });
 
   await t.step("works with single guard", () => {
-    const justString = unionOf(isString as TypeGuard<string>);
+    const justString = unionOf(isString);
 
     assert(justString("hello"));
     assertFalse(justString(42));
   });
 
   await t.step("validates correctly with three or more guards", () => {
-    const isStringOrNumberOrBoolean = unionOf(isString as TypeGuard<string>, isNumber, isBoolean);
+    const isStringOrNumberOrBoolean = unionOf(isString, isNumber, isBoolean);
 
     assert(isStringOrNumberOrBoolean("hello"));
     assert(isStringOrNumberOrBoolean(42));
@@ -434,12 +440,12 @@ Deno.test("unionOf", async (t) => {
   });
 
   await t.step("validate method returns proper error messages", () => {
-    const isStringOrNumber = unionOf(isString as TypeGuard<string>, isNumber);
+    const isStringOrNumber = unionOf(isString, isNumber);
 
     assertEquals(isStringOrNumber.validate("hello"), { value: "hello" });
     assertEquals(isStringOrNumber.validate(42), { value: 42 });
     assertEquals(isStringOrNumber.validate(true), {
-      issues: [{ message: 'Expected string | number. Received: true' }],
+      issues: [{ message: "Expected string | number. Received: true" }],
     });
   });
 

--- a/packages/guardis/src/utilities.test.ts
+++ b/packages/guardis/src/utilities.test.ts
@@ -1,5 +1,6 @@
 import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
 import { createTypeGuard, isArray, isBoolean, isNull, isNumber, isString } from "./guard.ts";
+import type { TypeGuard } from "./types.ts";
 import {
   doesNotHaveProperty,
   exact,
@@ -407,7 +408,7 @@ Deno.test("formatErrorMessage", async (t) => {
 
 Deno.test("unionOf", async (t) => {
   await t.step("creates union from multiple guards", () => {
-    const isStringOrNumber = unionOf(isString, isNumber);
+    const isStringOrNumber = unionOf(isString as TypeGuard<string>, isNumber);
 
     assert(isStringOrNumber("hello"));
     assert(isStringOrNumber(42));
@@ -416,14 +417,14 @@ Deno.test("unionOf", async (t) => {
   });
 
   await t.step("works with single guard", () => {
-    const justString = unionOf(isString);
+    const justString = unionOf(isString as TypeGuard<string>);
 
     assert(justString("hello"));
     assertFalse(justString(42));
   });
 
   await t.step("validates correctly with three or more guards", () => {
-    const isStringOrNumberOrBoolean = unionOf(isString, isNumber, isBoolean);
+    const isStringOrNumberOrBoolean = unionOf(isString as TypeGuard<string>, isNumber, isBoolean);
 
     assert(isStringOrNumberOrBoolean("hello"));
     assert(isStringOrNumberOrBoolean(42));
@@ -433,7 +434,7 @@ Deno.test("unionOf", async (t) => {
   });
 
   await t.step("validate method returns proper error messages", () => {
-    const isStringOrNumber = unionOf(isString, isNumber);
+    const isStringOrNumber = unionOf(isString as TypeGuard<string>, isNumber);
 
     assertEquals(isStringOrNumber.validate("hello"), { value: "hello" });
     assertEquals(isStringOrNumber.validate(42), { value: 42 });


### PR DESCRIPTION
## Summary

- **`isInt` guard** — validates integers, rejects NaN/Infinity/floats. Chainable with the same comparison methods as `isNumber`
- **`.finite` modifier** on number guards — `isNumber.finite` rejects `Infinity` and `-Infinity`
- **`isEnum` factory** — creates a type guard from a TypeScript enum object, handles both string and numeric enums (filters reverse mappings)
- **String length modifiers** — `isString.min(n)`, `.max(n)`, `.range(min, max)`, `.ofLength(n)` for chainable length validation
- **`.brand()` method** on all type guards — zero-cost nominal typing via `guard.brand<"MyBrand">()`
- **Parser auto-compilation** — `createTypeGuard(parser)` now attempts to auto-compile parser callbacks into pre-resolved field descriptors at creation time, giving parser-based guards the same fast-fail boolean path as shape-based guards
- **Refined type chains** — `NumberTypeGuard.eq()` and `StringTypeGuard` terminal methods return plain `TypeGuard` to prevent nonsensical chains (e.g. `isNumber.eq(5).gt(3)`)
- **`Brand` type** moved from `brand.ts` to `types.ts` for shared access

## Test plan

- [x] All existing tests pass
- [x] New tests for `isInt`, `isInt.finite`, number `.finite` modifier
- [x] New tests for `isEnum` with string, numeric, and mixed enums
- [x] New tests for string length modifiers (`min`, `max`, `range`, `ofLength`)
- [x] New tests for `.brand()` method on type guards
- [x] Parser auto-compilation benchmark comparing compiled vs uncompiled paths