### PR TITLE
guardis-hono 0.1.0

### DIFF
--- a/packages/guardis-hono/deno.json
+++ b/packages/guardis-hono/deno.json
@@ -14,6 +14,11 @@
     "include": ["mod.ts", "README.md", "deno.json"],
     "exclude": ["**/*.test.ts"]
   },
+  "imports": {
+    "@spudlabs/guardis": "jsr:@spudlabs/guardis@^0.8.0",
+    "hono": "npm:hono@^4.10.0",
+    "hono/": "npm:/hono@^4.10.0/"
+  },
   "compilerOptions": {},
   "fmt": {
     "lineWidth": 100

--- a/packages/guardis-hono/deno.json
+++ b/packages/guardis-hono/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@spudlabs/guardis-hono",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "license": "MIT",
   "description": "Guardis utilities for use with the Hono API framework.",
   "exports": {

--- a/packages/guardis-hono/scripts/build_npm.ts
+++ b/packages/guardis-hono/scripts/build_npm.ts
@@ -26,8 +26,6 @@ await build({
     license,
     peerDependencies: {
       hono: "^4.10.0",
-    },
-    dependencies: {
       [guardisConfig.name]: `^${guardisConfig.version}`,
     },
     keywords: [
@@ -48,9 +46,15 @@ await build({
   },
   postBuild() {
     Deno.copyFileSync("README.md", "npm/README.md");
-    // Remove hono from dependencies — it should only be a peerDependency
+    // dnt duplicates peerDependencies into dependencies so its ESM/CJS output
+    // can resolve them at build time. Strip the duplicates back out so hono
+    // and @spudlabs/guardis are peers only.
     const pkg = JSON.parse(Deno.readTextFileSync("npm/package.json"));
-    delete pkg.dependencies.hono;
+    if (pkg.dependencies) {
+      delete pkg.dependencies.hono;
+      delete pkg.dependencies[guardisConfig.name];
+      if (Object.keys(pkg.dependencies).length === 0) delete pkg.dependencies;
+    }
     Deno.writeTextFileSync("npm/package.json", JSON.stringify(pkg, null, 2) + "\n");
   },
 });


### PR DESCRIPTION
## Summary

Ships guardis-hono 0.1.0 with a single behavioral change: move \`@spudlabs/guardis\` from \`dependencies\` to \`peerDependencies\`.

## Why

Declaring guardis as a regular dependency caused consumers to end up with two copies of the library at runtime — one resolved by guardis-hono's own lockfile, one resolved by the app. When a guard created against a newer guardis was passed into hono's validator (which was running the older bundled copy), the two versions' \`Context\` shapes disagreed and crashed with \`ctx.popPath is not a function\`.

Making guardis a peer lets the consumer pick the version and guarantees a single copy at runtime.

## Changes

- \`scripts/build_npm.ts\`: move \`@spudlabs/guardis\` into \`peerDependencies\` (range \`^0.8.0\`); \`hono ^4.10.0\` stays a peer as before. The \`postBuild\` step strips the dnt-duplicated entries out of \`dependencies\` so the emitted npm package has peers only.
- \`deno.json\`: bumped to \`0.1.0\` (minor — peer-dep transition is a consumer-facing change).

The rebase on \`main\` brings in guardis 0.8.0 so the peer range resolves correctly.

## Test plan

- [x] \`deno test --allow-net\` in \`packages/guardis-hono\` — 24 passed
- [x] \`deno run -A scripts/build_npm.ts\` builds cleanly
- [x] Emitted \`npm/package.json\` has \`peerDependencies: { hono, @spudlabs/guardis }\` and no \`dependencies\` block