### PR TITLE
feat: add or() helper for parser-callback forks

### DIFF
--- a/packages/guardis/README.md
+++ b/packages/guardis/README.md
@@ -296,8 +296,11 @@ The callback in `createTypeGuard` provides these helpers:
 
 - **`has(obj, key, guard)`** — validate a required property
 - **`hasOptional(obj, key, guard)`** — validate an optional property (`T | undefined`)
+- **`hasNot(obj, key)`** — assert a property is absent
 - **`tupleHas(arr, index, guard)`** — validate a tuple element at an index
 - **`includes(array, value)`** — check membership in a `const` array (useful for union types)
+- **`or(val, ...branches)`** — express fork logic: match one of several alternative shapes
+- **`fail(message)`** — add a validation issue and return `null`
 
 ```ts
 type Status = "pending" | "complete" | "failed";
@@ -307,6 +310,45 @@ const isStatus = createTypeGuard<Status>((val, { includes }) => {
   return isString(val) && includes(valid, val) ? val : null;
 });
 ```
+
+### Forking Inside a Parser
+
+When a value can match one of several alternative shapes that share a validation prefix, use `or()`:
+
+```ts
+type OrgMember  = { kind: string; orgId:   string };
+type UserMember = { kind: string; userId:  string };
+
+const isMember = createTypeGuard<OrgMember | UserMember>((val, { has, or }) => {
+  if (!isObject(val) || !has(val, "kind", isString)) return null;
+  return or(
+    val,
+    (v): v is OrgMember  => has(v, "orgId",  isString),
+    (v): v is UserMember => has(v, "userId", isString),
+  ) ? val : null;
+});
+```
+
+Each branch is a predicate that receives `val` as `v` and returns a boolean. If any branch matches, `or()` returns `true` and narrows `val` to the union of branch result types. If all branches fail:
+
+- **Boolean mode**: `or()` returns `false`.
+- **Validate mode**: all branches' issues surface in `result.issues`.
+- **Strict mode**: `or()` throws a `TypeError` with combined branch info.
+
+**Why not `if (has(...))`?** The natural-looking pattern below is a footgun — do not use it for forks:
+
+```ts
+// ❌ Broken: in validate/strict modes, has() is designed to collect errors in
+// && chains. It returns true on failure when a ctx is present, so the first
+// branch always wins and the type assertion lies.
+if (has(val, "orgId",  isString)) return val;
+if (has(val, "userId", isString)) return val;
+```
+
+`has()`'s always-true-on-failure behavior is intentional — it lets
+`has(v,'a') && has(v,'b') && has(v,'c')` in validate mode collect every
+field's error in one pass. That design means `if (has(...))` can't be used
+as a fork condition. `or()` is the correct primitive for branching.
 
 ## Extending Guards
 

--- a/packages/guardis/deno.json
+++ b/packages/guardis/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@spudlabs/guardis",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "license": "MIT",
   "description": "Guardis is a modular library of type guards, built to be easy to use and extend.",
   "exports": {

--- a/packages/guardis/src/context.test.ts
+++ b/packages/guardis/src/context.test.ts
@@ -1,0 +1,167 @@
+import { assert, assertEquals, assertStrictEquals, assertThrows } from "@std/assert";
+import type { StandardSchemaV1 } from "../specs/standard-schema-spec.v1.ts";
+import type { Context } from "./types.ts";
+import { createContext, createStrictContext } from "./context.ts";
+
+// `_speculative` and `_strict` are internal fields not on the public Context interface.
+// Tests access them via this local cast.
+type InternalContext = Context & {
+  _speculative?: StandardSchemaV1.Issue[];
+  _strict?: true;
+};
+
+Deno.test("createContext addIssue", async (t) => {
+  await t.step("pushes to issues when no speculation is active", () => {
+    const ctx = createContext();
+    ctx.addIssue("err1");
+    assertEquals(ctx.issues.length, 1);
+    assertEquals(ctx.issues[0], { message: "err1" });
+  });
+
+  await t.step("includes path when path has segments", () => {
+    const ctx = createContext();
+    ctx.pushPath("user");
+    ctx.pushPath("name");
+    ctx.addIssue("err");
+    assertEquals(ctx.issues[0], { message: "err", path: ["user", "name"] });
+  });
+
+  await t.step("omits path at root", () => {
+    const ctx = createContext();
+    ctx.addIssue("err");
+    assertEquals(ctx.issues[0], { message: "err" });
+  });
+});
+
+Deno.test("createContext speculation slot", async (t) => {
+  await t.step("addIssue routes to speculation buffer when set", () => {
+    const ctx = createContext() as InternalContext;
+    const buf: StandardSchemaV1.Issue[] = [];
+    ctx._speculative = buf;
+    ctx.addIssue("speculative err");
+    assertEquals(buf.length, 1);
+    assertEquals(buf[0], { message: "speculative err" });
+    assertEquals(ctx.issues.length, 0);
+  });
+
+  await t.step("clearing speculation routes subsequent writes back to issues", () => {
+    const ctx = createContext() as InternalContext;
+    const buf: StandardSchemaV1.Issue[] = [];
+    ctx._speculative = buf;
+    ctx.addIssue("a");
+    ctx._speculative = undefined;
+    ctx.addIssue("b");
+    assertEquals(buf.length, 1);
+    assertEquals(buf[0], { message: "a" });
+    assertEquals(ctx.issues.length, 1);
+    assertEquals(ctx.issues[0], { message: "b" });
+  });
+
+  await t.step("defensive path copy — path mutation after issue does not affect buffer", () => {
+    const ctx = createContext() as InternalContext;
+    const buf: StandardSchemaV1.Issue[] = [];
+    ctx._speculative = buf;
+    ctx.pushPath("keep");
+    ctx.addIssue("captured");
+    ctx.popPath();
+    ctx.pushPath("different");
+    // First issue's path must still contain "keep", proving we stored a copy.
+    assertEquals(buf[0].path, ["keep"]);
+  });
+
+  await t.step("_speculative is undefined when not set", () => {
+    const ctx = createContext() as InternalContext;
+    assertEquals(ctx._speculative, undefined);
+  });
+});
+
+Deno.test("createStrictContext addIssue", async (t) => {
+  await t.step("throws TypeError when no speculation is active", () => {
+    const ctx = createStrictContext();
+    assertThrows(() => ctx.addIssue("err"), TypeError, "err");
+  });
+
+  await t.step("throw includes path", () => {
+    const ctx = createStrictContext();
+    ctx.pushPath("field");
+    assertThrows(() => ctx.addIssue("err"), TypeError, "err at path: field");
+  });
+
+  await t.step("omits path clause at root", () => {
+    const ctx = createStrictContext();
+    try {
+      ctx.addIssue("err");
+      assert(false, "should have thrown");
+    } catch (e) {
+      assert(e instanceof TypeError);
+      assertEquals(e.message, "err");
+    }
+  });
+});
+
+Deno.test("createStrictContext speculation slot", async (t) => {
+  await t.step("addIssue pushes to buffer and does NOT throw when speculation is active", () => {
+    const ctx = createStrictContext() as InternalContext;
+    const buf: StandardSchemaV1.Issue[] = [];
+    ctx._speculative = buf;
+    ctx.addIssue("would-throw-but-speculative");
+    assertEquals(buf.length, 1);
+    assertEquals(buf[0], { message: "would-throw-but-speculative" });
+  });
+
+  await t.step("defensive path copy in strict speculation mode", () => {
+    const ctx = createStrictContext() as InternalContext;
+    const buf: StandardSchemaV1.Issue[] = [];
+    ctx._speculative = buf;
+    ctx.pushPath("x");
+    ctx.addIssue("err");
+    ctx.popPath();
+    ctx.pushPath("y");
+    assertEquals(buf[0].path, ["x"]);
+  });
+
+  await t.step("clearing speculation restores throw behavior", () => {
+    const ctx = createStrictContext() as InternalContext;
+    const buf: StandardSchemaV1.Issue[] = [];
+    ctx._speculative = buf;
+    ctx.addIssue("buffered");
+    ctx._speculative = undefined;
+    assertThrows(() => ctx.addIssue("now throws"), TypeError);
+  });
+});
+
+Deno.test("createStrictContext _strict marker", async (t) => {
+  await t.step("strict ctx has _strict === true", () => {
+    const ctx = createStrictContext() as InternalContext;
+    assertStrictEquals(ctx._strict, true);
+  });
+
+  await t.step("non-strict ctx does not have _strict set", () => {
+    const ctx = createContext() as InternalContext;
+    assertEquals(ctx._strict, undefined);
+  });
+});
+
+Deno.test("save/restore speculation nesting", async (t) => {
+  await t.step("nested save/restore preserves outer buffer", () => {
+    const ctx = createContext() as InternalContext;
+    const outerBuf: StandardSchemaV1.Issue[] = [];
+    const innerBuf: StandardSchemaV1.Issue[] = [];
+
+    ctx._speculative = outerBuf;
+    ctx.addIssue("outer1");
+
+    // Simulate nested or(): save outer, install inner, restore outer.
+    const prev = ctx._speculative;
+    ctx._speculative = innerBuf;
+    ctx.addIssue("inner1");
+    ctx._speculative = prev;
+
+    ctx.addIssue("outer2");
+
+    assertEquals(outerBuf.map((i) => i.message), ["outer1", "outer2"]);
+    assertEquals(innerBuf.map((i) => i.message), ["inner1"]);
+    // ctx.issues untouched throughout.
+    assertEquals(ctx.issues.length, 0);
+  });
+});

--- a/packages/guardis/src/context.ts
+++ b/packages/guardis/src/context.ts
@@ -8,6 +8,12 @@ import type { Context } from "./types.ts";
  * in place. Callers must push and pop in matched pairs. `addIssue` defensively copies
  * the path so captured issues remain stable after the cursor unwinds.
  *
+ * **Speculation slot** (`_speculative`, internal — not on the public `Context` interface):
+ * when set to an Issue[] by `or()` (see `guard.ts`), `addIssue` writes to that buffer
+ * instead of `issues`. This lets `or()` isolate branch-level issue writes without
+ * allocating fresh contexts. `or()` is the only caller that reads/writes `_speculative`;
+ * it accesses via a local cast `(ctx as Context & { _speculative?: Issue[] })`.
+ *
  * @param path The initial path segments (defaults to empty array for root)
  * @param rootIssues Optional shared issues array
  * @returns A new Context instance
@@ -17,10 +23,17 @@ export function createContext(
   rootIssues?: StandardSchemaV1.Issue[],
 ): Context {
   const issues = rootIssues ?? [];
+  let speculative: StandardSchemaV1.Issue[] | undefined;
 
-  return {
+  const ctx = {
     path,
     issues,
+    get _speculative(): StandardSchemaV1.Issue[] | undefined {
+      return speculative;
+    },
+    set _speculative(v: StandardSchemaV1.Issue[] | undefined) {
+      speculative = v;
+    },
     pushPath(segment: PropertyKey): void {
       path.push(segment);
     },
@@ -28,10 +41,12 @@ export function createContext(
       path.pop();
     },
     addIssue(message: string): void {
-      // Only include path if it has segments (not at root level)
-      issues.push(path.length > 0 ? { message, path: [...path] } : { message });
+      const target = speculative ?? issues;
+      // Defensive path copy — path keeps mutating after this issue is captured.
+      target.push(path.length > 0 ? { message, path: [...path] } : { message });
     },
-  };
+  } as Context;
+  return ctx;
 }
 
 /**
@@ -42,13 +57,30 @@ export function createContext(
  * issue, the cursor never unwinds — but the shared API simplifies call sites, and the
  * thrown error's path reflects the deepest push at throw time.
  *
+ * **Speculation slot** (`_speculative`, internal): when set, `addIssue` writes to the
+ * buffer and does NOT throw. `or()` uses this to run speculative branches non-throwingly.
+ * See `createContext` docstring for details.
+ *
+ * **Strict marker** (`_strict: true`, internal): `or()` reads this via local cast to
+ * decide whether to throw a combined TypeError or push issues after all branches fail.
+ * Not part of the public `Context` interface.
+ *
  * @param path The initial path segments (defaults to empty array for root)
  * @returns A Context that throws on addIssue instead of collecting issues
  */
 export function createStrictContext(path: PropertyKey[] = []): Context {
-  return {
+  let speculative: StandardSchemaV1.Issue[] | undefined;
+
+  const ctx = {
     path,
     issues: [],
+    _strict: true as const,
+    get _speculative(): StandardSchemaV1.Issue[] | undefined {
+      return speculative;
+    },
+    set _speculative(v: StandardSchemaV1.Issue[] | undefined) {
+      speculative = v;
+    },
     pushPath(segment: PropertyKey): void {
       path.push(segment);
     },
@@ -56,8 +88,14 @@ export function createStrictContext(path: PropertyKey[] = []): Context {
       path.pop();
     },
     addIssue(message: string): void {
+      if (speculative) {
+        // Defensive path copy — matches non-strict addIssue.
+        speculative.push(path.length > 0 ? { message, path: [...path] } : { message });
+        return;
+      }
       const pathStr = path.length > 0 ? ` at path: ${path.join(".")}` : "";
       throw new TypeError(`${message}${pathStr}`);
     },
-  };
+  } as Context;
+  return ctx;
 }

--- a/packages/guardis/src/guard.test.ts
+++ b/packages/guardis/src/guard.test.ts
@@ -3882,3 +3882,509 @@ Deno.test("Parser auto-compilation safety", async (t) => {
     assertFalse(isPerson({ name: "Alice" }));
   });
 });
+
+// ---------------------------------------------------------------------------
+// or() helper — fork primitive for parser callbacks.
+// ---------------------------------------------------------------------------
+
+Deno.test("or() — boolean mode", async (t) => {
+  type OrgMember = { a: string; orgId: string };
+  type UserMember = { a: string; userId: string };
+  type Member = OrgMember | UserMember;
+
+  const isMember = createTypeGuard<Member>((val, { has, or }) => {
+    if (!isObject(val) || !has(val, "a", isString)) return null;
+    return or(
+      val,
+      (v) => has(v, "orgId", isString),
+      (v) => has(v, "userId", isString),
+    )
+      ? val
+      : null;
+  });
+
+  await t.step("first branch matches", () => {
+    assert(isMember({ a: "x", orgId: "org-1" }));
+  });
+
+  await t.step("second branch matches", () => {
+    assert(isMember({ a: "x", userId: "user-1" }));
+  });
+
+  await t.step("no branch matches", () => {
+    assertFalse(isMember({ a: "x" }));
+    assertFalse(isMember({ a: "x", other: "thing" }));
+  });
+
+  await t.step("prefix fails short-circuits before or", () => {
+    assertFalse(isMember({ orgId: "org-1" })); // no 'a'
+  });
+
+  await t.step("or() with zero branches throws", () => {
+    const guard = createTypeGuard<unknown>((val, { or }) => {
+      // deno-lint-ignore no-explicit-any
+      return (or as any)(val) ? val : null;
+    });
+    assertThrows(() => guard({}), Error, "or() requires at least one branch");
+  });
+
+  await t.step("single-branch or() runs the branch", () => {
+    const guard = createTypeGuard<unknown>((val, { has, or }) => {
+      if (!isObject(val)) return null;
+      return or(val, (v) => has(v, "x", isString)) ? val : null;
+    });
+    assert(guard({ x: "hi" }));
+    assertFalse(guard({ x: 1 }));
+    assertFalse(guard({}));
+  });
+
+  await t.step("branch returning null (via fail) is treated as falsy", () => {
+    const guard = createTypeGuard<unknown>((val, { has, or, fail }) => {
+      if (!isObject(val)) return null;
+      return or(
+        val,
+        (v) => has(v, "x", isString) ? true : fail("no x"),
+        (v) => has(v, "y", isString),
+      )
+        ? val
+        : null;
+    });
+    assert(guard({ x: "ok" }));
+    assert(guard({ y: "ok" }));
+    assertFalse(guard({ z: "no" }));
+  });
+
+  await t.step("branch returning undefined is treated as falsy", () => {
+    const guard = createTypeGuard<unknown>((val, { has, or }) => {
+      if (!isObject(val)) return null;
+      return or(
+        val,
+        () => undefined,
+        (v) => has(v, "y", isString),
+      )
+        ? val
+        : null;
+    });
+    assert(guard({ y: "ok" }));
+    assertFalse(guard({}));
+  });
+
+  await t.step("type narrowing — typed predicate branches narrow val", () => {
+    type Shape = { a: number } | { b: string };
+    const guard = createTypeGuard<Shape>((val, { has, or }) => {
+      if (!isObject(val)) return null;
+      if (
+        or(
+          val,
+          (v): v is { a: number } => has(v, "a", isNumber),
+          (v): v is { b: string } => has(v, "b", isString),
+        )
+      ) {
+        // Compile-time proof that val is narrowed: if `or()` did not narrow,
+        // returning `val` from the parser (whose return type is Shape | null)
+        // would be a type error. This implicit narrowing assertion is the
+        // test — no runtime assertion needed beyond the outer guard behavior.
+        return val;
+      }
+      return null;
+    });
+    assert(guard({ a: 1 }));
+    assert(guard({ b: "hi" }));
+    assertFalse(guard({ c: true }));
+  });
+});
+
+Deno.test("or() — validate mode", async (t) => {
+  const isMember = createTypeGuard<unknown>((val, { has, or }) => {
+    if (!isObject(val) || !has(val, "a", isString)) return null;
+    return or(
+      val,
+      (v) => has(v, "orgId", isString),
+      (v) => has(v, "userId", isString),
+    )
+      ? val
+      : null;
+  });
+
+  await t.step("first branch matches — value returned, no issues", () => {
+    const r = isMember.validate({ a: "x", orgId: "org-1" });
+    assert("value" in r);
+    assertEquals(r.value, { a: "x", orgId: "org-1" });
+  });
+
+  await t.step(
+    "second branch matches — value returned, first branch's speculative issues discarded",
+    () => {
+      const r = isMember.validate({ a: "x", userId: "user-1" });
+      assert("value" in r);
+      assertEquals(r.value, { a: "x", userId: "user-1" });
+    },
+  );
+
+  await t.step("no branch matches — issues from every branch, flat", () => {
+    const r = isMember.validate({ a: "x" });
+    assert("issues" in r && r.issues);
+    // Both branches added "Missing required property: orgId" / "...: userId".
+    assert(r.issues.length >= 2, `expected ≥2 issues, got ${r.issues.length}`);
+    const messages = r.issues.map((i) => i.message).join("|");
+    assert(messages.includes("orgId"));
+    assert(messages.includes("userId"));
+  });
+
+  await t.step(
+    "critical invariant: has() returns true on context-aware guard failure — or() still catches via buffer check",
+    () => {
+      // Branch's `has(v, 'orgId', isString.notEmpty)` uses a context-aware guard
+      // (isString.notEmpty has _.context). On an empty-string value, has()
+      // returns true but the inner guard adds an issue to the speculation buffer.
+      // or() must see buf.length > 0 and treat the branch as failed.
+      const isStrict = createTypeGuard<unknown>((val, { has, or }) => {
+        if (!isObject(val)) return null;
+        return or(
+          val,
+          (v) => has(v, "orgId", isString.notEmpty),
+          (v) => has(v, "orgName", isString),
+        )
+          ? val
+          : null;
+      });
+
+      // orgId is an empty string — first branch's inner guard fails.
+      // orgName is present and valid — second branch matches.
+      const r = isStrict.validate({ orgId: "", orgName: "Acme" });
+      assert(
+        "value" in r,
+        `expected value, got: ${JSON.stringify(r)}`,
+      );
+    },
+  );
+
+  await t.step(
+    "critical invariant: has() errorMessage path — or() catches via buffer check",
+    () => {
+      // Branch uses `has(v, 'k', guard, 'custom err')` — the errorMessage path
+      // in hasProperty writes the custom message and (per existing v0.7
+      // semantics) returns true. or() must catch via buffer check.
+      const guard = createTypeGuard<unknown>((val, { has, or }) => {
+        if (!isObject(val)) return null;
+        return or(
+          val,
+          (v) => has(v, "age", isNumber, "age must be a number"),
+          (v) => has(v, "label", isString),
+        )
+          ? val
+          : null;
+      });
+
+      // age is a string — first branch fails via errorMessage path.
+      // label is present — second branch matches.
+      const r = guard.validate({ age: "not-a-number", label: "ok" });
+      assert("value" in r, `expected value, got: ${JSON.stringify(r)}`);
+    },
+  );
+
+  await t.step("nested context-aware guard inside branch — failure caught by or", () => {
+    const isInner = createTypeGuard<{ x: string }>((val, { has }) => {
+      if (!isObject(val)) return null;
+      return has(val, "x", isString) ? val : null;
+    });
+
+    const guard = createTypeGuard<unknown>((val, { has, or }) => {
+      if (!isObject(val)) return null;
+      return or(
+        val,
+        // inner guard fails — its issues land in the speculation buffer
+        (v) => has(v, "inner", isInner),
+        (v) => has(v, "fallback", isString),
+      )
+        ? val
+        : null;
+    });
+
+    // inner is present but invalid (missing x); fallback is present — or picks it.
+    const r = guard.validate({ inner: { y: 1 }, fallback: "ok" });
+    assert("value" in r, `expected value, got: ${JSON.stringify(r)}`);
+  });
+
+  await t.step("nested or — inner or inside outer or branch composes", () => {
+    const guard = createTypeGuard<unknown>((val, { has, or }) => {
+      if (!isObject(val)) return null;
+      return or(
+        val,
+        (v) =>
+          isObject(v) && has(v, "a", isString) && or(
+            v,
+            (vv) => has(vv, "b", isString),
+            (vv) => has(vv, "c", isString),
+          ),
+        (v) => has(v, "alt", isString),
+      )
+        ? val
+        : null;
+    });
+
+    assert("value" in guard.validate({ a: "x", b: "y" }));
+    assert("value" in guard.validate({ a: "x", c: "y" }));
+    assert("value" in guard.validate({ alt: "z" }));
+    assert("issues" in guard.validate({ a: "x" })); // a present but neither b nor c, nor alt
+    assert("issues" in guard.validate({}));
+  });
+
+  await t.step("speculation buffer restored after each branch", () => {
+    // A ctx.addIssue call OUTSIDE or() after or() runs must not land in a
+    // speculation buffer — proves we restored _speculative to undefined.
+    const guard = createTypeGuard<unknown>((val, { has, or, fail }) => {
+      if (!isObject(val)) return null;
+      // Fork fails, then we emit a top-level issue via fail().
+      or(
+        val,
+        (v) => has(v, "x", isString),
+      );
+      // Regardless of or's result, emit an unrelated issue.
+      return fail("top-level issue after or");
+    });
+
+    const r = guard.validate({});
+    assert("issues" in r && r.issues);
+    const messages = r.issues.map((i) => i.message);
+    assert(
+      messages.includes("top-level issue after or"),
+      `expected top-level issue to appear in ctx.issues, got: ${messages.join(", ")}`,
+    );
+  });
+});
+
+Deno.test("or() — strict mode", async (t) => {
+  const isMember = createTypeGuard<unknown>((val, { has, or }) => {
+    if (!isObject(val) || !has(val, "a", isString)) return null;
+    return or(
+      val,
+      (v) => has(v, "orgId", isString),
+      (v) => has(v, "userId", isString),
+    )
+      ? val
+      : null;
+  });
+
+  await t.step("first branch matches — no throw", () => {
+    isMember.strict({ a: "x", orgId: "org-1" });
+  });
+
+  await t.step("second branch matches — no throw", () => {
+    isMember.strict({ a: "x", userId: "user-1" });
+  });
+
+  await t.step("no branch matches — throws TypeError with combined info", () => {
+    try {
+      isMember.strict({ a: "x" });
+      assert(false, "should have thrown");
+    } catch (e) {
+      assert(e instanceof Error);
+      // Combined message references both branches.
+      assert(
+        e.message.includes("branch 0") && e.message.includes("branch 1"),
+        `expected combined info, got: ${e.message}`,
+      );
+    }
+  });
+
+  await t.step("strict addIssue still throws when called outside or", () => {
+    // Sanity check — the speculation slot must only be set inside or().
+    const guard = createTypeGuard<unknown>((_val, { fail }) => {
+      fail("explicit failure");
+      return null;
+    });
+    assertThrows(() => guard.strict({}), TypeError, "explicit failure");
+  });
+});
+
+Deno.test("or() — compile probe integration", async (t) => {
+  // These tests verify tryCompileParser correctly emits union descriptors for
+  // or()-using parsers, and that the boolean fast-path evaluates any-branch-
+  // matches correctly.
+
+  await t.step("or() parser auto-compiles and matches first branch", () => {
+    const isMember = createTypeGuard<unknown>((val, { has, or }) => {
+      if (!isObject(val) || !has(val, "kind", isString)) return null;
+      return or(
+        val,
+        (v) => has(v, "orgId", isString),
+        (v) => has(v, "userId", isString),
+      )
+        ? val
+        : null;
+    });
+    // Boolean path hits the compiled descriptors; first branch matches.
+    assert(isMember({ kind: "org", orgId: "o-1" }));
+  });
+
+  await t.step("or() parser auto-compiles and matches second branch", () => {
+    const isMember = createTypeGuard<unknown>((val, { has, or }) => {
+      if (!isObject(val) || !has(val, "kind", isString)) return null;
+      return or(
+        val,
+        (v) => has(v, "orgId", isString),
+        (v) => has(v, "userId", isString),
+      )
+        ? val
+        : null;
+    });
+    // Crucial — this is the scenario that broke under the pre-fix linearization
+    // (probe recorded both branches as required, so fast-path needed both).
+    assert(isMember({ kind: "user", userId: "u-1" }));
+  });
+
+  await t.step("or() parser rejects value matching no branch", () => {
+    const isMember = createTypeGuard<unknown>((val, { has, or }) => {
+      if (!isObject(val) || !has(val, "kind", isString)) return null;
+      return or(
+        val,
+        (v) => has(v, "orgId", isString),
+        (v) => has(v, "userId", isString),
+      )
+        ? val
+        : null;
+    });
+    assertFalse(isMember({ kind: "foo", other: "bar" }));
+    assertFalse(isMember({ orgId: "o-1" })); // missing 'kind'
+  });
+
+  await t.step("each probe helper (has/hasOptional/hasNot) writes to per-branch accumulator", () => {
+    // Exercises all three compile-trackable probe helpers inside different branches
+    // to prove per-branch field isolation.
+    const isShape = createTypeGuard<unknown>((val, { has, hasOptional, hasNot, or }) => {
+      if (!isObject(val)) return null;
+      return or(
+        val,
+        (v) => has(v, "a", isString), // branch 0: one required
+        (v) => hasOptional(v, "b", isNumber) && has(v, "c", isString), // branch 1: optional + required
+        (v) => has(v, "d", isString) && hasNot(v, "e"), // branch 2: required + absent
+      )
+        ? val
+        : null;
+    });
+    assert(isShape({ a: "x" }));
+    assert(isShape({ b: 1, c: "y" }));
+    assert(isShape({ c: "y" })); // b is optional
+    assert(isShape({ d: "z" }));
+    assertFalse(isShape({ d: "z", e: "forbidden" })); // branch 2's hasNot rejects
+    assertFalse(isShape({})); // matches no branch
+  });
+
+  await t.step("nested or composes through compilation", () => {
+    const guard = createTypeGuard<unknown>((val, { has, or }) => {
+      if (!isObject(val)) return null;
+      return or(
+        val,
+        (v) => has(v, "wrapper", isString),
+        (v) =>
+          has(v, "kind", isString) && or(
+            v,
+            (vv) => has(vv, "inner1", isString),
+            (vv) => has(vv, "inner2", isString),
+          ),
+      )
+        ? val
+        : null;
+    });
+    assert(guard({ wrapper: "w" }));
+    assert(guard({ kind: "k", inner1: "x" }));
+    assert(guard({ kind: "k", inner2: "y" }));
+    assertFalse(guard({ kind: "k" })); // no inner1/inner2
+    assertFalse(guard({}));
+  });
+
+  await t.step(
+    "branch using non-compile-friendly helper (fail) bails to closure",
+    () => {
+      // Using fail() inside a branch marks the probe as failed, so the parser
+      // falls back to the closure at runtime. The closure path uses the ctx-aware
+      // or() which still gives correct semantics — test that the overall guard
+      // still works.
+      const guard = createTypeGuard<unknown>((val, { has, or, fail }) => {
+        if (!isObject(val)) return null;
+        return or(
+          val,
+          (v) => {
+            // The fail() call makes this branch non-compilable.
+            if (!has(v, "x", isString)) return fail("no x");
+            return true;
+          },
+          (v) => has(v, "y", isString),
+        )
+          ? val
+          : null;
+      });
+      // Boolean mode still works — runs the closure since probe bailed.
+      assert(guard({ x: "ok" }));
+      assert(guard({ y: "ok" }));
+      assertFalse(guard({ z: "nope" }));
+    },
+  );
+
+  await t.step("empty union branch (no probe-tracked helpers) bails compilation", () => {
+    // A branch that doesn't call any compile-trackable helper (e.g. a pure
+    // function like `() => true`) has opaque compile semantics — the probe
+    // correctly bails, falling back to the closure for correct runtime behavior.
+    const guard = createTypeGuard<unknown>((val, { has, or }) => {
+      if (!isObject(val)) return null;
+      return or(
+        val,
+        () => true, // empty-branch — probe bails
+        (v) => has(v, "y", isString),
+      )
+        ? val
+        : null;
+    });
+    // `() => true` wins at runtime for any object; guard accepts any record.
+    assert(guard({ anything: "goes" }));
+    assert(guard({ y: "ok" }));
+    assertFalse(guard(42)); // not an object, isObject check fails
+    assertFalse(guard(null));
+  });
+});
+
+Deno.test("or() — regression: Problem Frame minimal repro", async (t) => {
+  // The exact scenario from the origin doc's Problem Frame:
+  //   if (has(v, 'a', isString)) {
+  //     if (has(v, 'orgId',   isUUIDv7))          return val;
+  //     if (has(v, 'orgName', isString.notEmpty)) return val;
+  //   }
+  //   return null;
+  // This form was broken. The or()-based rewrite:
+  const guard = createTypeGuard<unknown>((val, { has, or }) => {
+    if (!isObject(val) || !has(val, "a", isString)) return null;
+    return or(
+      val,
+      (v) => has(v, "orgId", isString),
+      (v) => has(v, "orgName", isString.notEmpty),
+    )
+      ? val
+      : null;
+  });
+
+  await t.step("boolean mode matches orgName branch (the case that failed)", () => {
+    assert(guard({ a: "x", orgName: "foo" }));
+  });
+
+  await t.step("validate mode matches orgName branch cleanly", () => {
+    const r = guard.validate({ a: "x", orgName: "foo" });
+    assert("value" in r);
+  });
+
+  await t.step("strict mode matches orgName branch without throwing", () => {
+    guard.strict({ a: "x", orgName: "foo" });
+  });
+
+  await t.step("orgId branch also matches in all modes", () => {
+    assert(guard({ a: "x", orgId: "some-id" }));
+    assert("value" in guard.validate({ a: "x", orgId: "some-id" }));
+    guard.strict({ a: "x", orgId: "some-id" });
+  });
+
+  await t.step("value matching neither branch is rejected", () => {
+    assertFalse(guard({ a: "x" }));
+    assert("issues" in guard.validate({ a: "x" }));
+    assertThrows(() => guard.strict({ a: "x" }), TypeError);
+  });
+});

--- a/packages/guardis/src/guard.test.ts
+++ b/packages/guardis/src/guard.test.ts
@@ -4388,3 +4388,184 @@ Deno.test("or() — regression: Problem Frame minimal repro", async (t) => {
     assertThrows(() => guard.strict({ a: "x" }), TypeError);
   });
 });
+
+// ---------------------------------------------------------------------------
+// && chain assertions in parser callbacks — regression coverage.
+// These tests lock down that `hasProperty` and `tupleHas` are intentionally
+// unchanged: has(v,'a') && has(v,'b') && has(v,'c') inside a parser still
+// collects every field's error in validate mode. If this breaks, the "or()
+// handles forks, && handles assertions" division of labor is compromised.
+// ---------------------------------------------------------------------------
+
+Deno.test("&& chain inside parser — multi-error collection (validate mode)", async (t) => {
+  const isShape = createTypeGuard<unknown>((val, { has }) =>
+    isObject(val) &&
+      has(val, "a", isString) &&
+      has(val, "b", isNumber) &&
+      has(val, "c", isBoolean)
+      ? val
+      : null
+  );
+
+  await t.step("all three fields invalid — all three issues reported", () => {
+    const r = isShape.validate({ a: 1, b: "not a number", c: "not a bool" });
+    assert("issues" in r && r.issues, "expected issues result");
+    // The full point of hasProperty's "return true on failure when ctx is set"
+    // contract: && doesn't short-circuit on the first failure, so every has()
+    // in the chain contributes its issue.
+    assertEquals(
+      r.issues.length,
+      3,
+      `expected 3 issues (one per failing field), got ${r.issues.length}: ${
+        r.issues.map((i) => i.message).join(" | ")
+      }`,
+    );
+    const paths = r.issues.map((i) => (i.path ?? []).join("."));
+    assert(paths.includes("a"), `missing 'a' path, got: ${paths.join(", ")}`);
+    assert(paths.includes("b"), `missing 'b' path, got: ${paths.join(", ")}`);
+    assert(paths.includes("c"), `missing 'c' path, got: ${paths.join(", ")}`);
+  });
+
+  await t.step("only middle field invalid — one issue with correct path", () => {
+    const r = isShape.validate({ a: "ok", b: "wrong", c: true });
+    assert("issues" in r && r.issues);
+    assertEquals(r.issues.length, 1);
+    assertEquals((r.issues[0].path ?? []).join("."), "b");
+  });
+
+  await t.step(
+    "missing key short-circuits && chain (missing returns false, not true)",
+    () => {
+      // Design detail worth locking in: hasProperty returns `false` when the
+      // KEY is missing, but `true` when the key exists and only the guard
+      // fails. That asymmetry means && short-circuits on the first missing
+      // key but keeps running past type mismatches. Only one issue here.
+      const r = isShape.validate({ a: "ok" /* missing b and c */ });
+      assert("issues" in r && r.issues);
+      assertEquals(r.issues.length, 1);
+      assertEquals((r.issues[0].path ?? []).join("."), "b");
+    },
+  );
+
+  await t.step(
+    "all present but type-invalid — all issues reported via context-aware path",
+    () => {
+      // With all keys present, guard failures route through the
+      // `hasContext(guard)` branch in hasProperty which returns true and
+      // writes the issue — so the && chain doesn't short-circuit.
+      const r = isShape.validate({ a: 1, b: "nope", c: "nope" });
+      assert("issues" in r && r.issues);
+      assertEquals(r.issues.length, 3);
+    },
+  );
+
+  await t.step("all valid — clean value, no issues", () => {
+    const r = isShape.validate({ a: "ok", b: 1, c: true });
+    assert("value" in r);
+    assertEquals(r.value, { a: "ok", b: 1, c: true });
+  });
+});
+
+Deno.test("&& chain with custom errorMessage — all custom messages collected", async (t) => {
+  // errorMessage path in hasProperty also returns true on failure to keep
+  // the chain running. Verify that design is preserved.
+  const isPerson = createTypeGuard<unknown>((val, { has }) =>
+    isObject(val) &&
+      has(val, "name", isString, "Name is required") &&
+      has(val, "age", isNumber, "Age must be a number") &&
+      has(val, "email", isString, "Email is required")
+      ? val
+      : null
+  );
+
+  await t.step("multiple errorMessage failures all land in ctx.issues", () => {
+    const r = isPerson.validate({ name: 42, age: "old" /* missing email */ });
+    assert("issues" in r && r.issues);
+    assertEquals(r.issues.length, 3, `got ${r.issues.length} issues`);
+    const messages = r.issues.map((i) => i.message);
+    assert(messages.includes("Name is required"));
+    assert(messages.includes("Age must be a number"));
+    assert(messages.includes("Email is required"));
+  });
+});
+
+Deno.test("mixing && chains with or() forks in a single parser", async (t) => {
+  // Real-world pattern: a common prefix validated via && chain, then a fork
+  // via or(). Both mechanisms must work together.
+  const isMember = createTypeGuard<unknown>((val, { has, or }) => {
+    if (
+      !isObject(val) ||
+      !has(val, "createdAt", isString) ||
+      !has(val, "kind", isString)
+    ) {
+      return null;
+    }
+    return or(
+      val,
+      (v) => has(v, "orgId", isString),
+      (v) => has(v, "userId", isString),
+    )
+      ? val
+      : null;
+  });
+
+  await t.step("valid prefix + matching branch — value returned", () => {
+    const r = isMember.validate({
+      createdAt: "2026-01-01",
+      kind: "org",
+      orgId: "o-1",
+    });
+    assert("value" in r);
+  });
+
+  await t.step("prefix fails — or() never runs, prefix issue reported", () => {
+    // Prefix && chain fails because `createdAt` is missing.
+    // The parser short-circuits before or(), so or() doesn't contribute issues.
+    const r = isMember.validate({ kind: "org", orgId: "o-1" });
+    assert("issues" in r && r.issues);
+    const messages = r.issues.map((i) => i.message).join(" | ");
+    assert(messages.includes("createdAt"), `expected createdAt issue, got: ${messages}`);
+    // Critically: no "Missing orgId / userId" issues from or() branches —
+    // the fork never executed.
+    assert(!messages.includes("orgId"), `or() should not have run: ${messages}`);
+    assert(!messages.includes("userId"), `or() should not have run: ${messages}`);
+  });
+
+  await t.step("prefix valid but no branch matches — prefix clean, or() issues replay", () => {
+    const r = isMember.validate({ createdAt: "2026-01-01", kind: "org" });
+    assert("issues" in r && r.issues);
+    const messages = r.issues.map((i) => i.message).join(" | ");
+    // Both or() branches failed — their speculative issues replay.
+    assert(messages.includes("orgId"), `expected orgId issue, got: ${messages}`);
+    assert(messages.includes("userId"), `expected userId issue, got: ${messages}`);
+    // Prefix fields were valid — no spurious createdAt/kind issues.
+    assert(!messages.includes("createdAt"));
+  });
+
+  await t.step("&& chain inside a branch still collects branch-scoped errors", () => {
+    // A branch that uses && inside: if the branch's first has() fails, the
+    // second has() still runs (preserving chain semantics). Both issues land
+    // in the speculation buffer, proving speculation doesn't break && chains.
+    const guard = createTypeGuard<unknown>((val, { has, or }) => {
+      if (!isObject(val)) return null;
+      return or(
+        val,
+        (v) => has(v, "a", isNumber) && has(v, "b", isNumber), // compound branch
+        (v) => has(v, "fallback", isString),
+      )
+        ? val
+        : null;
+    });
+
+    // First branch: both a and b invalid — both issues land in speculation buffer.
+    // Second branch: fallback missing. Everything fails.
+    const r = guard.validate({ a: "no", b: "no" });
+    assert("issues" in r && r.issues);
+    const messages = r.issues.map((i) => i.message).join(" | ");
+    // First branch's speculation buffer captured both a and b issues, plus
+    // the second branch's fallback issue — all three replay flat.
+    assert(messages.includes("a"), `expected 'a' issue: ${messages}`);
+    assert(messages.includes("b"), `expected 'b' issue: ${messages}`);
+    assert(messages.includes("fallback"), `expected 'fallback' issue: ${messages}`);
+  });
+});

--- a/packages/guardis/src/guard.ts
+++ b/packages/guardis/src/guard.ts
@@ -102,6 +102,66 @@ function createHelpers(ctx?: Context): HelpersWithContext {
     }
   };
 
+  // Fork primitive: or(val, ...branches). Runtime behavior splits on whether a
+  // Context is active (validate/strict vs. boolean mode).
+  const or = <V>(
+    val: V,
+    // deno-lint-ignore no-explicit-any
+    ...branches: ReadonlyArray<(v: V) => any>
+  ): boolean => {
+    if (branches.length === 0) {
+      throw new Error("or() requires at least one branch");
+    }
+
+    // Boolean mode: trivial short-circuit.
+    if (!ctx) {
+      for (const branch of branches) {
+        if (branch(val) === true) return true;
+      }
+      return false;
+    }
+
+    // Ctx-aware mode: speculation stack. Each branch runs with a scoped issue
+    // buffer. A branch "succeeds" only if it returned strict `true` AND wrote
+    // no issues (compensates for has()'s always-true-on-failure contract in
+    // validate mode; see origin doc's "has() and or() interaction").
+    const specCtx = ctx as Context & {
+      _speculative?: StandardSchemaV1.Issue[];
+      _strict?: true;
+    };
+    const collected: StandardSchemaV1.Issue[][] = [];
+
+    for (const branch of branches) {
+      const buf: StandardSchemaV1.Issue[] = [];
+      const prev = specCtx._speculative;
+      specCtx._speculative = buf;
+      let ok: unknown;
+      try {
+        ok = branch(val);
+      } finally {
+        specCtx._speculative = prev;
+      }
+      if (ok === true && buf.length === 0) return true;
+      collected.push(buf);
+    }
+
+    // All branches failed.
+    if (specCtx._strict) {
+      const combined = collected
+        .map((list, i) => {
+          const msgs = list.map((issue) => issue.message).join("; ");
+          return `branch ${i}: ${msgs || "(no issue recorded)"}`;
+        })
+        .join(" | ");
+      throw new TypeError(`or() — no branch matched: ${combined}`);
+    }
+
+    for (const list of collected) {
+      for (const issue of list) ctx.issues.push(issue);
+    }
+    return false;
+  };
+
   return {
     has,
     hasNot,
@@ -115,8 +175,9 @@ function createHelpers(ctx?: Context): HelpersWithContext {
       if (ctx) ctx.addIssue(message);
       return null;
     },
+    or,
     _ctx: ctx,
-  };
+  } as HelpersWithContext;
 }
 
 /** Default helpers for boolean type guard calls (no validation context) */
@@ -157,7 +218,12 @@ type FieldDescriptor =
   | { kind: "nested"; key: string; fields: FieldDescriptor[] }
   | { kind: "typePredicate"; key: string; guard: (value: unknown) => boolean }
   | { kind: "required"; key: string }
-  | { kind: "absent"; key: string };
+  | { kind: "absent"; key: string }
+  // Union of alternative branches (emitted by probe when a parser uses or()).
+  // No `key` — represents a choice across the whole value at this position.
+  // Each branch is a FieldDescriptor[] that must all-pass for that branch to
+  // match; any-branch-matches is sufficient for the union to pass.
+  | { kind: "union"; branches: FieldDescriptor[][] };
 
 /**
  * Compiles a TypeGuardShape into a pre-resolved array of field descriptors.
@@ -202,6 +268,12 @@ function compileShape(shape: TypeGuardShape): FieldDescriptor[] {
 
 /**
  * Validates a single pre-compiled field descriptor against an object value.
+ *
+ * Path handling: `pushPath`/`popPath` is gated on `'key' in desc` so that future
+ * non-keyed variants (e.g. union descriptors from `or()`) skip path tracking —
+ * those are choices across the whole value, not property-scoped. Inside each
+ * `case`, the switch has already narrowed `desc` to the specific variant, so
+ * `desc.key` is type-safe without an extra guard.
  */
 function validateCompiledField(
   obj: Record<string, unknown>,
@@ -210,16 +282,14 @@ function validateCompiledField(
   localIssues: StandardSchemaV1.Issue[],
   result: Record<string, unknown>,
 ): void {
-  const key = desc.key;
-
-  if (ctx) ctx.pushPath(key);
+  if ("key" in desc && ctx) ctx.pushPath(desc.key);
 
   try {
     switch (desc.kind) {
       case "nested": {
-        const r = validateCompiledShape(obj[key], desc.fields, ctx);
+        const r = validateCompiledShape(obj[desc.key], desc.fields, ctx);
         if ("value" in r) {
-          result[key] = r.value;
+          result[desc.key] = r.value;
         } else if (!ctx) {
           localIssues.push(...r.issues);
         }
@@ -228,21 +298,21 @@ function validateCompiledField(
 
       case "typeGuard": {
         if (ctx) {
-          const r = desc.guard._.context(obj[key], ctx);
-          if ("value" in r) result[key] = r.value;
+          const r = desc.guard._.context(obj[desc.key], ctx);
+          if ("value" in r) result[desc.key] = r.value;
 
           // Issues are already in ctx.issues — guards write directly via addIssue.
         } else {
           // No ctx — call without context arg to hit the bypass path (defaultHelpers,
           // no createContext/createHelpers allocation). Prepend the field key to paths.
-          const r = desc.guard._.context(obj[key]);
+          const r = desc.guard._.context(obj[desc.key]);
           if ("value" in r) {
-            result[key] = r.value;
+            result[desc.key] = r.value;
           } else {
             for (const issue of r.issues) {
               localIssues.push({
                 message: issue.message,
-                path: issue.path ? [key, ...issue.path] : [key],
+                path: issue.path ? [desc.key, ...issue.path] : [desc.key],
               });
             }
           }
@@ -251,45 +321,57 @@ function validateCompiledField(
       }
 
       case "typePredicate": {
-        if (desc.guard(obj[key])) {
-          result[key] = obj[key];
+        if (desc.guard(obj[desc.key])) {
+          result[desc.key] = obj[desc.key];
         } else {
-          const message = `Validation failed for property "${String(key)}"`;
+          const message = `Validation failed for property "${String(desc.key)}"`;
           if (ctx) {
             ctx.addIssue(message);
           } else {
-            localIssues.push({ message, path: [key] });
+            localIssues.push({ message, path: [desc.key] });
           }
         }
         break;
       }
       case "required": {
-        if (key in obj) {
-          result[key] = obj[key];
+        if (desc.key in obj) {
+          result[desc.key] = obj[desc.key];
         } else {
-          const message = `Missing required property: ${key}`;
+          const message = `Missing required property: ${desc.key}`;
           if (ctx) {
             ctx.addIssue(message);
           } else {
-            localIssues.push({ message, path: [key] });
+            localIssues.push({ message, path: [desc.key] });
           }
         }
         break;
       }
       case "absent": {
-        if (key in obj) {
-          const message = `Property must not be present: ${key}`;
+        if (desc.key in obj) {
+          const message = `Property must not be present: ${desc.key}`;
           if (ctx) {
             ctx.addIssue(message);
           } else {
-            localIssues.push({ message, path: [key] });
+            localIssues.push({ message, path: [desc.key] });
           }
         }
         break;
       }
+      case "union": {
+        // Unreachable today: tryCompileParser falls back to the original closure
+        // whenever helpers._ctx is set (the validate/slow path), and shape-
+        // compiled guards never produce union descriptors. Loud-fail so that
+        // any future change to either invariant surfaces immediately instead
+        // of silently miscompiling.
+        throw new Error(
+          "Internal: union descriptor reached validateCompiledField — " +
+            "slow-path union handling is not implemented. " +
+            "See docs/plans/2026-04-15-001-feat-or-helper-for-parser-forks-plan.md",
+        );
+      }
     }
   } finally {
-    if (ctx) ctx.popPath();
+    if ("key" in desc && ctx) ctx.popPath();
   }
 }
 
@@ -306,28 +388,41 @@ function validateCompiledShapeBoolean(
 
   for (let i = 0; i < fields.length; i++) {
     const desc = fields[i];
-    const key = desc.key;
 
     switch (desc.kind) {
       case "nested": {
-        if (!validateCompiledShapeBoolean(value[key], desc.fields)) return false;
+        if (!validateCompiledShapeBoolean(value[desc.key], desc.fields)) return false;
         break;
       }
       case "typeGuard": {
         // Call the raw boolean callback directly — no context, no helpers, no issues.
-        if (!desc.guard(value[key])) return false;
+        if (!desc.guard(value[desc.key])) return false;
         break;
       }
       case "typePredicate": {
-        if (!desc.guard(value[key])) return false;
+        if (!desc.guard(value[desc.key])) return false;
         break;
       }
       case "required": {
-        if (!(key in value)) return false;
+        if (!(desc.key in value)) return false;
         break;
       }
       case "absent": {
-        if (key in value) return false;
+        if (desc.key in value) return false;
+        break;
+      }
+      case "union": {
+        // Any-branch-matches wins. Each branch is a FieldDescriptor[] that
+        // must all pass for that branch to match. If no branch matches, the
+        // whole union fails and this field — and thus the outer shape — fails.
+        let matched = false;
+        for (const branch of desc.branches) {
+          if (validateCompiledShapeBoolean(value, branch)) {
+            matched = true;
+            break;
+          }
+        }
+        if (!matched) return false;
         break;
       }
     }
@@ -550,8 +645,13 @@ function classifyGuard(
  * and the caller falls back to the original closure-based parser.
  */
 function tryCompileParser<T1>(parser: Parser<T1>): Parser<T1> | null {
-  const fields: FieldDescriptor[] = [];
-  let failed = false;
+  // `fields` is a mutable holder rather than a closure-local const so that the
+  // probe's `or` entry can swap in a fresh per-branch accumulator, run the
+  // branch, and restore. Every probe helper push site references
+  // `fieldsHolder.current` — not a captured `fields` variable — so swaps are
+  // visible to `has`, `hasOptional`, `hasNot`, and nested `or`.
+  const fieldsHolder: { current: FieldDescriptor[] } = { current: [] };
+  let failed: boolean = false;
 
   const probe = new Proxy({} as Record<string, unknown>, {
     has() {
@@ -580,9 +680,9 @@ function tryCompileParser<T1>(parser: Parser<T1>): Parser<T1> | null {
       if (failed) return true;
 
       if (guard) {
-        fields.push(classifyGuard(String(k), guard));
+        fieldsHolder.current.push(classifyGuard(String(k), guard));
       } else {
-        fields.push({ kind: "required", key: String(k) });
+        fieldsHolder.current.push({ kind: "required", key: String(k) });
       }
       return true;
     }) as HelpersWithContext["has"],
@@ -592,23 +692,23 @@ function tryCompileParser<T1>(parser: Parser<T1>): Parser<T1> | null {
       if (guard && hasContext(guard as Predicate<unknown>)) {
         const g = guard as TypeGuard<unknown>;
         if (g.optional) {
-          fields.push({
+          fieldsHolder.current.push({
             kind: "typeGuard",
             key: String(k),
             guard: g.optional as TypeGuard<unknown>,
           });
         } else {
-          fields.push(classifyGuard(String(k), guard));
+          fieldsHolder.current.push(classifyGuard(String(k), guard));
         }
       } else if (guard) {
-        fields.push({ kind: "typePredicate", key: String(k), guard });
+        fieldsHolder.current.push({ kind: "typePredicate", key: String(k), guard });
       }
       return true;
     }) as HelpersWithContext["hasOptional"],
     hasNot: ((_t: object, k: PropertyKey) => {
       if (failed) return true;
 
-      fields.push({ kind: "absent", key: String(k) });
+      fieldsHolder.current.push({ kind: "absent", key: String(k) });
       return true;
     }) as HelpersWithContext["hasNot"],
     tupleHas: (() => {
@@ -631,15 +731,73 @@ function tryCompileParser<T1>(parser: Parser<T1>): Parser<T1> | null {
       failed = true;
       return null;
     }) as HelpersWithContext["fail"],
+    or: ((
+      _val: unknown,
+      // deno-lint-ignore no-explicit-any
+      ...branches: ReadonlyArray<(v: unknown) => any>
+    ) => {
+      if (failed) return true;
+      if (branches.length === 0) {
+        failed = true;
+        return false;
+      }
+
+      const perBranchFields: FieldDescriptor[][] = [];
+      for (const branch of branches) {
+        // Save outer state.
+        const savedFields: FieldDescriptor[] = fieldsHolder.current;
+        const savedFailed: boolean = failed;
+
+        // Install fresh per-branch accumulator.
+        fieldsHolder.current = [];
+        failed = false;
+
+        try {
+          branch(probe as unknown);
+        } catch {
+          // User branch threw — treat as uncompilable.
+          failed = true;
+        }
+
+        const branchFields = fieldsHolder.current;
+        const branchFailed = failed;
+
+        // Restore outer state, OR'ing the branch's failed flag into outer.
+        fieldsHolder.current = savedFields;
+        failed = savedFailed || branchFailed;
+
+        if (branchFailed) {
+          // Bail the whole `or` — caller will fall back to closure path.
+          return true;
+        }
+        if (branchFields.length === 0) {
+          // Empty branch: the branch called no compile-trackable helpers, so
+          // its compiled semantics would be "matches anything" — which doesn't
+          // match the branch's actual runtime behavior (e.g., a branch that
+          // just returns false/undefined). Bail compilation to preserve
+          // correctness.
+          failed = true;
+          return true;
+        }
+        perBranchFields.push(branchFields);
+      }
+
+      fieldsHolder.current.push({ kind: "union", branches: perBranchFields });
+      return true;
+    }) as unknown as HelpersWithContext["or"],
     _ctx: undefined,
   };
 
   try {
     const result = parser(probe as unknown, probeHelpers);
-    if (result !== probe || failed || fields.length === 0) return null;
+    if (result !== probe || failed || fieldsHolder.current.length === 0) return null;
   } catch {
     return null;
   }
+
+  // Snapshot the fields at compile time — the holder is mutable but compilation
+  // is done, so we freeze a reference to what was accumulated.
+  const fields = fieldsHolder.current;
 
   // Compilation succeeded — use compiled fields for the boolean fast path,
   // but fall back to the original parser for the validate path to preserve

--- a/packages/guardis/src/types.ts
+++ b/packages/guardis/src/types.ts
@@ -28,6 +28,17 @@ export interface Context {
   addIssue(message: string): void;
 }
 
+// Non-exported local aliases for `or()` — they exist solely to express its
+// signature and are not part of the public API. Do not export.
+type BranchPredicate<V> = (v: V) => boolean | null | undefined;
+// Using `(v: any)` in the conditional lets TS match any type predicate without
+// the "R could be unrelated to V" constraint error. The intersection `V & R`
+// yields the narrowed type at the `or` callsite when a branch is a typed predicate.
+type BranchNarrowing<V, P extends readonly BranchPredicate<V>[]> = {
+  // deno-lint-ignore no-explicit-any
+  [K in keyof P]: P[K] extends (v: any) => v is infer R ? V & R : V;
+}[number];
+
 type Helpers = {
   /** Check for required property with optional custom error message */
   has: <K extends PropertyKey, G = unknown>(
@@ -61,6 +72,33 @@ type Helpers = {
   exact: <const T>(expected: T, v: unknown) => v is T;
   /** Returns null and adds custom error message to context if during validation */
   fail: (message: string) => null;
+  /**
+   * Fork primitive: evaluates alternative branch predicates against `val`, narrowing
+   * `val` to the union of branch result types on success.
+   *
+   * Signature: `or(val, branch1, branch2, ...)`. Branches receive `v: V` and either
+   * return a plain `boolean` or are typed as `(v: V) => v is SubType` (narrows at
+   * the `or` callsite on success). TS 5.5+ infers the predicate return type from
+   * single-expression branch bodies that call another type predicate (including
+   * `has`).
+   *
+   * Use `or()` instead of `if (has(...)) ... if (has(...))` patterns — the latter
+   * is broken for forks in validate/strict modes because `has()` intentionally
+   * returns `true` on failure to support `&&`-chain multi-error collection.
+   *
+   * @example
+   * ```ts
+   * return or(
+   *   val,
+   *   (v) => has(v, "orgId",   isUUIDv7),
+   *   (v) => has(v, "orgName", isString.notEmpty),
+   * ) ? val : null;
+   * ```
+   */
+  or: <V, P extends readonly BranchPredicate<V>[]>(
+    val: V,
+    ...branches: P
+  ) => val is V & BranchNarrowing<V, P>;
 };
 
 /** Helpers extended with internal context access for validation */


### PR DESCRIPTION
## Summary

Adds `or(val, ...branches)` to the parser-callback `Helpers` API — a first-class fork primitive that handles ctx isolation, strict-mode safety, type narrowing, and parser auto-compilation correctly across all four evaluation modes (boolean, validate, strict, compile-probe).

## Why

The natural-looking pattern for forks inside a parser is broken three ways:

```ts
// ❌ This is broken in validate/strict modes — first branch always wins
if (has(val, 'orgId',   isString)) return val;
if (has(val, 'orgName', isString)) return val;
```

1. `hasProperty` returns `true` on failure when a ctx is present (intentional — so `&&`-chain assertions can collect multi-error). That makes `if (has(...))` always truthy in validate mode.
2. `tryCompileParser` linearizes both branches' fields into a single required-field list, so the boolean fast-path rejects valid values.
3. Strict-ctx `addIssue` throws before the fallback branch can run.

The right tool for forks needs ctx isolation, type narrowing through branch predicates, strict-mode safety, and correct compile-probe handling. That's `or()`:

```ts
// ✅ Correct
return or(
  val,
  (v): v is OrgMember  => has(v, "orgId",  isString),
  (v): v is UserMember => has(v, "userId", isString),
) ? val : null;
```

## What changed

**`packages/guardis/src/context.ts`** — added internal `_speculative` slot (closure-captured) on both context factories. When set, `addIssue` writes to the buffer instead of `issues`; strict-mode `addIssue` does not throw. `createStrictContext` exposes an internal `_strict: true` marker. Defensive path copy preserved throughout.

**`packages/guardis/src/types.ts`** — added `or` to the `Helpers` type with full JSDoc. `BranchPredicate<V>` and `BranchNarrowing<V, P>` are non-exported local aliases.

**`packages/guardis/src/guard.ts`** — added `or` runtime to `createHelpers` (boolean short-circuit + speculation stack for ctx-aware modes). Added `{ kind: \"union\" }` to `FieldDescriptor`. Refactored `validateCompiledField` and `validateCompiledShapeBoolean` to use `'key' in desc` discriminant narrowing so the new union variant skips path tracking. Probe rewrite: `fields` is now a mutable holder so `probeHelpers.or` can swap in per-branch accumulators; empty-branch (no compile-trackable helpers) bails compilation to preserve runtime semantics.

**`packages/guardis/README.md`** — new \"Forking Inside a Parser\" section with the rationale and example. Helpers list now includes `or`, `hasNot`, `fail`.

**`packages/guardis/deno.json`** — bumped 0.7.4 → 0.8.0 (purely additive).

### Critical invariant

`has()` in validate mode returns `true` even when a context-aware guard fails (by design — keeps `&&` chains collecting multi-error). That means `or()` cannot trust the boolean return alone. **A branch is treated as successful only when it returns strict `true` AND produces no speculative issues.** The speculation buffer carries the truth.

## What's NOT changed

`hasProperty`, `tupleHas`, and `hasOptionalProperty` behavior is intentionally preserved. The existing `has(a) && has(b) && has(c)` pattern keeps collecting every field's error in validate mode — locked in by new explicit tests.

## Test plan

- [x] `or()` boolean mode — branch matching, narrowing, edge cases (zero/single/`null`/`undefined` branches)
- [x] `or()` validate mode — branch wins / all fail / discarded speculative issues
- [x] `or()` validate mode critical-invariant tests covering both `has()` always-true paths (`hasContext` and `errorMessage`) plus nested context-aware guards inside branches
- [x] `or()` strict mode — no-throw on success, combined `TypeError` on total failure, no speculation leak outside `or()`
- [x] `or()` compile-probe integration — auto-compiles, both branches matched via fast-path, every probe helper exercised inside branches, nested `or` composes, non-compile-friendly helpers fall back to closure, empty-branch bails compilation
- [x] Problem Frame minimal repro — works in all four modes after `or()` rewrite
- [x] `&&` chain regression coverage — multi-error collection preserved (context-aware path, errorMessage path, mixed prefix + `or()` parsers, `&&` chain inside an `or()` branch)
- [x] Full suite: **120 passed, 898 steps, 0 failed**