### PR TITLE
guardis 0.8.1

### DIFF
--- a/packages/guardis/deno.json
+++ b/packages/guardis/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@spudlabs/guardis",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "description": "Guardis is a modular library of type guards, built to be easy to use and extend.",
   "exports": {

--- a/packages/guardis/src/guard.test.ts
+++ b/packages/guardis/src/guard.test.ts
@@ -1,19 +1,7 @@
 import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
 import type { StandardSchemaV1 } from "../specs/standard-schema-spec.v1.ts";
-import {
-  createTypeGuard,
-  isExactly,
-  isNull,
-  isUndefined,
-} from "./guard.ts";
-import {
-  isArray,
-  isBoolean,
-  isNil,
-  isNumber,
-  isObject,
-  isString,
-} from "./modules/primitives.ts";
+import { createTypeGuard, isExactly, isNull, isUndefined } from "./guard.ts";
+import { isArray, isBoolean, isNil, isNumber, isObject, isString } from "./modules/primitives.ts";
 import type { GuardedType, TypeGuard } from "./types.ts";
 import { assertType, type Equals } from "./test-utils.ts";
 
@@ -1299,9 +1287,7 @@ Deno.test("Guard name edge cases", async (t) => {
   await t.step("notEmpty of unnamed guard has undefined name on metadata", () => {
     // The cast in createNotEmptyTypeGuard must still yield an undefined name
     // when the inner guard has no name — not a stringified "undefined".
-    const anonymous = createTypeGuard((v): string | null =>
-      typeof v === "string" ? v : null
-    );
+    const anonymous = createTypeGuard((v): string | null => typeof v === "string" ? v : null);
     assertEquals(
       (anonymous.notEmpty as unknown as TypeGuard<string>)._.name,
       undefined,
@@ -3753,11 +3739,11 @@ Deno.test("createTypeGuard with verified shape (explicit type parameter)", async
 
     const isPaginated = buildPaginatedGuard(["name", "createdAt"]);
 
-    assertFalse(isPaginated({}));                                             // id required, missing
-    assert(isPaginated({ id: 1 }));                                           // minimal valid
-    assert(isPaginated({ id: 1, search: "hi", page: 2, sortBy: "name" }));   // all fields valid
-    assertFalse(isPaginated({ id: 1, sortBy: "unknown" }));                   // sortBy not in keys
-    assertFalse(isPaginated({ id: 1, page: "2" }));                           // page wrong type
+    assertFalse(isPaginated({})); // id required, missing
+    assert(isPaginated({ id: 1 })); // minimal valid
+    assert(isPaginated({ id: 1, search: "hi", page: 2, sortBy: "name" })); // all fields valid
+    assertFalse(isPaginated({ id: 1, sortBy: "unknown" })); // sortBy not in keys
+    assertFalse(isPaginated({ id: 1, page: "2" })); // page wrong type
   });
 });
 
@@ -3931,10 +3917,10 @@ Deno.test("or() — boolean mode", async (t) => {
   const isMember = createTypeGuard<Member>((val, { has, or }) => {
     if (!isObject(val) || !has(val, "a", isString)) return null;
     return or(
-      val,
-      (v) => has(v, "orgId", isString),
-      (v) => has(v, "userId", isString),
-    )
+        val,
+        (v) => has(v, "orgId", isString),
+        (v) => has(v, "userId", isString),
+      )
       ? val
       : null;
   });
@@ -3978,10 +3964,10 @@ Deno.test("or() — boolean mode", async (t) => {
     const guard = createTypeGuard<unknown>((val, { has, or, fail }) => {
       if (!isObject(val)) return null;
       return or(
-        val,
-        (v) => has(v, "x", isString) ? true : fail("no x"),
-        (v) => has(v, "y", isString),
-      )
+          val,
+          (v) => has(v, "x", isString) ? true : fail("no x"),
+          (v) => has(v, "y", isString),
+        )
         ? val
         : null;
     });
@@ -3994,10 +3980,10 @@ Deno.test("or() — boolean mode", async (t) => {
     const guard = createTypeGuard<unknown>((val, { has, or }) => {
       if (!isObject(val)) return null;
       return or(
-        val,
-        () => undefined,
-        (v) => has(v, "y", isString),
-      )
+          val,
+          () => undefined,
+          (v) => has(v, "y", isString),
+        )
         ? val
         : null;
     });
@@ -4034,10 +4020,10 @@ Deno.test("or() — validate mode", async (t) => {
   const isMember = createTypeGuard<unknown>((val, { has, or }) => {
     if (!isObject(val) || !has(val, "a", isString)) return null;
     return or(
-      val,
-      (v) => has(v, "orgId", isString),
-      (v) => has(v, "userId", isString),
-    )
+        val,
+        (v) => has(v, "orgId", isString),
+        (v) => has(v, "userId", isString),
+      )
       ? val
       : null;
   });
@@ -4077,10 +4063,10 @@ Deno.test("or() — validate mode", async (t) => {
       const isStrict = createTypeGuard<unknown>((val, { has, or }) => {
         if (!isObject(val)) return null;
         return or(
-          val,
-          (v) => has(v, "orgId", isString.notEmpty),
-          (v) => has(v, "orgName", isString),
-        )
+            val,
+            (v) => has(v, "orgId", isString.notEmpty),
+            (v) => has(v, "orgName", isString),
+          )
           ? val
           : null;
       });
@@ -4104,10 +4090,10 @@ Deno.test("or() — validate mode", async (t) => {
       const guard = createTypeGuard<unknown>((val, { has, or }) => {
         if (!isObject(val)) return null;
         return or(
-          val,
-          (v) => has(v, "age", isNumber, "age must be a number"),
-          (v) => has(v, "label", isString),
-        )
+            val,
+            (v) => has(v, "age", isNumber, "age must be a number"),
+            (v) => has(v, "label", isString),
+          )
           ? val
           : null;
       });
@@ -4128,11 +4114,11 @@ Deno.test("or() — validate mode", async (t) => {
     const guard = createTypeGuard<unknown>((val, { has, or }) => {
       if (!isObject(val)) return null;
       return or(
-        val,
-        // inner guard fails — its issues land in the speculation buffer
-        (v) => has(v, "inner", isInner),
-        (v) => has(v, "fallback", isString),
-      )
+          val,
+          // inner guard fails — its issues land in the speculation buffer
+          (v) => has(v, "inner", isInner),
+          (v) => has(v, "fallback", isString),
+        )
         ? val
         : null;
     });
@@ -4146,15 +4132,15 @@ Deno.test("or() — validate mode", async (t) => {
     const guard = createTypeGuard<unknown>((val, { has, or }) => {
       if (!isObject(val)) return null;
       return or(
-        val,
-        (v) =>
-          isObject(v) && has(v, "a", isString) && or(
-            v,
-            (vv) => has(vv, "b", isString),
-            (vv) => has(vv, "c", isString),
-          ),
-        (v) => has(v, "alt", isString),
-      )
+          val,
+          (v) =>
+            isObject(v) && has(v, "a", isString) && or(
+              v,
+              (vv) => has(vv, "b", isString),
+              (vv) => has(vv, "c", isString),
+            ),
+          (v) => has(v, "alt", isString),
+        )
         ? val
         : null;
     });
@@ -4194,10 +4180,10 @@ Deno.test("or() — strict mode", async (t) => {
   const isMember = createTypeGuard<unknown>((val, { has, or }) => {
     if (!isObject(val) || !has(val, "a", isString)) return null;
     return or(
-      val,
-      (v) => has(v, "orgId", isString),
-      (v) => has(v, "userId", isString),
-    )
+        val,
+        (v) => has(v, "orgId", isString),
+        (v) => has(v, "userId", isString),
+      )
       ? val
       : null;
   });
@@ -4243,10 +4229,10 @@ Deno.test("or() — compile probe integration", async (t) => {
     const isMember = createTypeGuard<unknown>((val, { has, or }) => {
       if (!isObject(val) || !has(val, "kind", isString)) return null;
       return or(
-        val,
-        (v) => has(v, "orgId", isString),
-        (v) => has(v, "userId", isString),
-      )
+          val,
+          (v) => has(v, "orgId", isString),
+          (v) => has(v, "userId", isString),
+        )
         ? val
         : null;
     });
@@ -4258,10 +4244,10 @@ Deno.test("or() — compile probe integration", async (t) => {
     const isMember = createTypeGuard<unknown>((val, { has, or }) => {
       if (!isObject(val) || !has(val, "kind", isString)) return null;
       return or(
-        val,
-        (v) => has(v, "orgId", isString),
-        (v) => has(v, "userId", isString),
-      )
+          val,
+          (v) => has(v, "orgId", isString),
+          (v) => has(v, "userId", isString),
+        )
         ? val
         : null;
     });
@@ -4274,10 +4260,10 @@ Deno.test("or() — compile probe integration", async (t) => {
     const isMember = createTypeGuard<unknown>((val, { has, or }) => {
       if (!isObject(val) || !has(val, "kind", isString)) return null;
       return or(
-        val,
-        (v) => has(v, "orgId", isString),
-        (v) => has(v, "userId", isString),
-      )
+          val,
+          (v) => has(v, "orgId", isString),
+          (v) => has(v, "userId", isString),
+        )
         ? val
         : null;
     });
@@ -4285,41 +4271,44 @@ Deno.test("or() — compile probe integration", async (t) => {
     assertFalse(isMember({ orgId: "o-1" })); // missing 'kind'
   });
 
-  await t.step("each probe helper (has/hasOptional/hasNot) writes to per-branch accumulator", () => {
-    // Exercises all three compile-trackable probe helpers inside different branches
-    // to prove per-branch field isolation.
-    const isShape = createTypeGuard<unknown>((val, { has, hasOptional, hasNot, or }) => {
-      if (!isObject(val)) return null;
-      return or(
-        val,
-        (v) => has(v, "a", isString), // branch 0: one required
-        (v) => hasOptional(v, "b", isNumber) && has(v, "c", isString), // branch 1: optional + required
-        (v) => has(v, "d", isString) && hasNot(v, "e"), // branch 2: required + absent
-      )
-        ? val
-        : null;
-    });
-    assert(isShape({ a: "x" }));
-    assert(isShape({ b: 1, c: "y" }));
-    assert(isShape({ c: "y" })); // b is optional
-    assert(isShape({ d: "z" }));
-    assertFalse(isShape({ d: "z", e: "forbidden" })); // branch 2's hasNot rejects
-    assertFalse(isShape({})); // matches no branch
-  });
+  await t.step(
+    "each probe helper (has/hasOptional/hasNot) writes to per-branch accumulator",
+    () => {
+      // Exercises all three compile-trackable probe helpers inside different branches
+      // to prove per-branch field isolation.
+      const isShape = createTypeGuard<unknown>((val, { has, hasOptional, hasNot, or }) => {
+        if (!isObject(val)) return null;
+        return or(
+            val,
+            (v) => has(v, "a", isString), // branch 0: one required
+            (v) => hasOptional(v, "b", isNumber) && has(v, "c", isString), // branch 1: optional + required
+            (v) => has(v, "d", isString) && hasNot(v, "e"), // branch 2: required + absent
+          )
+          ? val
+          : null;
+      });
+      assert(isShape({ a: "x" }));
+      assert(isShape({ b: 1, c: "y" }));
+      assert(isShape({ c: "y" })); // b is optional
+      assert(isShape({ d: "z" }));
+      assertFalse(isShape({ d: "z", e: "forbidden" })); // branch 2's hasNot rejects
+      assertFalse(isShape({})); // matches no branch
+    },
+  );
 
   await t.step("nested or composes through compilation", () => {
     const guard = createTypeGuard<unknown>((val, { has, or }) => {
       if (!isObject(val)) return null;
       return or(
-        val,
-        (v) => has(v, "wrapper", isString),
-        (v) =>
-          has(v, "kind", isString) && or(
-            v,
-            (vv) => has(vv, "inner1", isString),
-            (vv) => has(vv, "inner2", isString),
-          ),
-      )
+          val,
+          (v) => has(v, "wrapper", isString),
+          (v) =>
+            has(v, "kind", isString) && or(
+              v,
+              (vv) => has(vv, "inner1", isString),
+              (vv) => has(vv, "inner2", isString),
+            ),
+        )
         ? val
         : null;
     });
@@ -4340,14 +4329,14 @@ Deno.test("or() — compile probe integration", async (t) => {
       const guard = createTypeGuard<unknown>((val, { has, or, fail }) => {
         if (!isObject(val)) return null;
         return or(
-          val,
-          (v) => {
-            // The fail() call makes this branch non-compilable.
-            if (!has(v, "x", isString)) return fail("no x");
-            return true;
-          },
-          (v) => has(v, "y", isString),
-        )
+            val,
+            (v) => {
+              // The fail() call makes this branch non-compilable.
+              if (!has(v, "x", isString)) return fail("no x");
+              return true;
+            },
+            (v) => has(v, "y", isString),
+          )
           ? val
           : null;
       });
@@ -4365,10 +4354,10 @@ Deno.test("or() — compile probe integration", async (t) => {
     const guard = createTypeGuard<unknown>((val, { has, or }) => {
       if (!isObject(val)) return null;
       return or(
-        val,
-        () => true, // empty-branch — probe bails
-        (v) => has(v, "y", isString),
-      )
+          val,
+          () => true, // empty-branch — probe bails
+          (v) => has(v, "y", isString),
+        )
         ? val
         : null;
     });
@@ -4391,10 +4380,10 @@ Deno.test("or() — regression: Problem Frame minimal repro", async (t) => {
   const guard = createTypeGuard<unknown>((val, { has, or }) => {
     if (!isObject(val) || !has(val, "a", isString)) return null;
     return or(
-      val,
-      (v) => has(v, "orgId", isString),
-      (v) => has(v, "orgName", isString.notEmpty),
-    )
+        val,
+        (v) => has(v, "orgId", isString),
+        (v) => has(v, "orgName", isString.notEmpty),
+      )
       ? val
       : null;
   });
@@ -4537,10 +4526,10 @@ Deno.test("mixing && chains with or() forks in a single parser", async (t) => {
       return null;
     }
     return or(
-      val,
-      (v) => has(v, "orgId", isString),
-      (v) => has(v, "userId", isString),
-    )
+        val,
+        (v) => has(v, "orgId", isString),
+        (v) => has(v, "userId", isString),
+      )
       ? val
       : null;
   });
@@ -4585,10 +4574,10 @@ Deno.test("mixing && chains with or() forks in a single parser", async (t) => {
     const guard = createTypeGuard<unknown>((val, { has, or }) => {
       if (!isObject(val)) return null;
       return or(
-        val,
-        (v) => has(v, "a", isNumber) && has(v, "b", isNumber), // compound branch
-        (v) => has(v, "fallback", isString),
-      )
+          val,
+          (v) => has(v, "a", isNumber) && has(v, "b", isNumber), // compound branch
+          (v) => has(v, "fallback", isString),
+        )
         ? val
         : null;
     });

--- a/packages/guardis/src/guard.test.ts
+++ b/packages/guardis/src/guard.test.ts
@@ -3723,6 +3723,42 @@ Deno.test("createTypeGuard with verified shape (explicit type parameter)", async
     assertFalse(isPositive(-1));
     assertType<Equals<typeof isPositive._TYPE, number>>();
   });
+
+  await t.step("typed shape inside a generic function with a parameterized type", () => {
+    // Reproduces the bug: when T1 is itself generic (e.g. PaginatedRequest<T>),
+    // TS cannot prove T1 extends Record<string, unknown>, so the VerifiedShape
+    // overloads are rejected and TS falls back to the Parser overload, which
+    // then reports a misleading "'search' does not exist in type 'Parser<…>'".
+    type PaginatedRequest<T extends readonly string[]> = {
+      id: number;
+      search?: string;
+      page?: number;
+      sortBy?: T[number];
+    };
+
+    function buildPaginatedGuard<T extends readonly string[]>(sortByKeys: T) {
+      const isSortByKey = createTypeGuard<T[number]>((v) =>
+        typeof v === "string" && (sortByKeys as readonly string[]).includes(v)
+          ? (v as T[number])
+          : null
+      );
+
+      return createTypeGuard<PaginatedRequest<T>>("PaginatedQuery", {
+        id: isNumber,
+        search: isString.notEmpty.optional,
+        page: isNumber.optional,
+        sortBy: isSortByKey.optional,
+      });
+    }
+
+    const isPaginated = buildPaginatedGuard(["name", "createdAt"]);
+
+    assertFalse(isPaginated({}));                                             // id required, missing
+    assert(isPaginated({ id: 1 }));                                           // minimal valid
+    assert(isPaginated({ id: 1, search: "hi", page: 2, sortBy: "name" }));   // all fields valid
+    assertFalse(isPaginated({ id: 1, sortBy: "unknown" }));                   // sortBy not in keys
+    assertFalse(isPaginated({ id: 1, page: "2" }));                           // page wrong type
+  });
 });
 
 Deno.test("Parser auto-compilation safety", async (t) => {

--- a/packages/guardis/src/modules/primitives.test.ts
+++ b/packages/guardis/src/modules/primitives.test.ts
@@ -2098,8 +2098,144 @@ Deno.test("numeric comparison methods", async (t) => {
   await t.step("isNumeric has comparison methods", () => {
     assert(isNumeric.gt(0)(5));
     assert(isNumeric.gt(0)("5"));
+    assert(isNumeric.lt(10)("5"));
     assertFalse(isNumeric.gt(0)(-1));
     assertFalse(isNumeric.gt(0)("abc"));
+    assertFalse(isNumeric.lt(10)("11"));
+  });
+
+  await t.step("isNumeric.gt covers numbers and numeric strings", () => {
+    assert(isNumeric.gt(0)(5));
+    assert(isNumeric.gt(0)("5"));
+    assert(isNumeric.gt(0)(0.1));
+    assertFalse(isNumeric.gt(0)(0));
+    assertFalse(isNumeric.gt(0)("0"));
+    assertFalse(isNumeric.gt(0)(-1));
+    assertFalse(isNumeric.gt(0)("abc"));
+  });
+
+  await t.step("isNumeric.gte covers numbers and numeric strings", () => {
+    assert(isNumeric.gte(0)(0));
+    assert(isNumeric.gte(0)("0"));
+    assert(isNumeric.gte(0)(1));
+    assert(isNumeric.gte(0)("1"));
+    assertFalse(isNumeric.gte(0)(-1));
+    assertFalse(isNumeric.gte(0)("-1"));
+    assertFalse(isNumeric.gte(0)("abc"));
+  });
+
+  await t.step("isNumeric.lt covers numbers and numeric strings", () => {
+    assert(isNumeric.lt(10)(5));
+    assert(isNumeric.lt(10)("5"));
+    assert(isNumeric.lt(10)(9.9));
+    assertFalse(isNumeric.lt(10)(10));
+    assertFalse(isNumeric.lt(10)("10"));
+    assertFalse(isNumeric.lt(10)("11"));
+    assertFalse(isNumeric.lt(10)("abc"));
+  });
+
+  await t.step("isNumeric.lte covers numbers and numeric strings", () => {
+    assert(isNumeric.lte(10)(10));
+    assert(isNumeric.lte(10)("10"));
+    assert(isNumeric.lte(10)(5));
+    assert(isNumeric.lte(10)("5"));
+    assertFalse(isNumeric.lte(10)(11));
+    assertFalse(isNumeric.lte(10)("11"));
+    assertFalse(isNumeric.lte(10)("abc"));
+  });
+
+  await t.step("isNumeric.eq matches numbers only (strict equality)", () => {
+    // isNumeric preserves the original value; eq uses === so strings never match
+    assert(isNumeric.eq(42)(42));
+    assertFalse(isNumeric.eq(42)("42"));
+    assertFalse(isNumeric.eq(42)(43));
+    assertFalse(isNumeric.eq(42)("abc"));
+  });
+
+  await t.step("isNumeric.finite accepts finite numbers only", () => {
+    // isNumeric preserves the original value; Number.isFinite rejects strings
+    assert(isNumeric.finite(5));
+    assert(isNumeric.finite(0));
+    assertFalse(isNumeric.finite("5"));
+    assertFalse(isNumeric.finite(Infinity));
+    assertFalse(isNumeric.finite(-Infinity));
+    assertFalse(isNumeric.finite(NaN));
+    assertFalse(isNumeric.finite("abc"));
+  });
+
+  await t.step("isNumeric chaining gt and lt", () => {
+    const between = isNumeric.gt(-1).lt(1);
+    assert(between(0));
+    assert(between("0"));
+    assert(between(0.5));
+    assert(between("0.5"));
+    assertFalse(between(-1));
+    assertFalse(between("-1"));
+    assertFalse(between(1));
+    assertFalse(between("1"));
+  });
+
+  await t.step("isNumeric chaining gte and lte for range", () => {
+    const isPercentage = isNumeric.gte(0).lte(100);
+    assert(isPercentage(0));
+    assert(isPercentage("0"));
+    assert(isPercentage(50));
+    assert(isPercentage("50"));
+    assert(isPercentage(100));
+    assert(isPercentage("100"));
+    assertFalse(isPercentage(-1));
+    assertFalse(isPercentage("-1"));
+    assertFalse(isPercentage(101));
+    assertFalse(isPercentage("101"));
+  });
+
+  await t.step("isNumeric.validate returns structured results", () => {
+    assertEquals(isNumeric.gt(0).validate(5), { value: 5 });
+    assertEquals(isNumeric.gt(0).validate("5"), { value: "5" as unknown as number });
+    assertEquals(isNumeric.gt(0).validate(-1), {
+      issues: [{ message: "Expected > 0. Received: -1" }],
+    });
+    assertEquals(isNumeric.lt(10).validate("11"), {
+      issues: [{ message: "Expected < 10. Received: '11'" }],
+    });
+  });
+
+  await t.step("isNumeric.strict throws on failure", () => {
+    isNumeric.gt(0).strict(5);
+    isNumeric.gt(0).strict("5");
+    assertThrows(() => isNumeric.gt(0).strict(-1));
+    assertThrows(() => isNumeric.lt(10).strict("11"));
+  });
+
+  await t.step("isNumeric.or after comparison", () => {
+    const guard = isNumeric.gt(0).or(isNull);
+    assert(guard(5));
+    assert(guard("5"));
+    assert(guard(null));
+    assertFalse(guard(0));
+    assertFalse(guard(-1));
+    assertFalse(guard("abc"));
+  });
+
+  await t.step("isInt has comparison methods", () => {
+    assert(isInt.gt(0)(5));
+    assertFalse(isInt.gt(0)(5.5));
+    assertFalse(isInt.gt(0)("5"));
+    assert(isInt.gte(0)(0));
+    assert(isInt.lt(10)(5));
+    assert(isInt.lte(10)(10));
+    assert(isInt.eq(42)(42));
+    assertFalse(isInt.eq(42)(42.5));
+  });
+
+  await t.step("isInt chaining for range", () => {
+    const between = isInt.gte(1).lte(10);
+    assert(between(1));
+    assert(between(5));
+    assert(between(10));
+    assertFalse(between(0));
+    assertFalse(between(11));
+    assertFalse(between(5.5));
   });
 });
 

--- a/packages/guardis/src/modules/strings.test.ts
+++ b/packages/guardis/src/modules/strings.test.ts
@@ -18,6 +18,9 @@ Deno.test("isEmail", async (t) => {
     assert(isEmail("user.name+tag+sorting@example.com"));
     assert(isEmail("user_name@example.co.uk"));
     assert(isEmail("user-name@sub.domain.com"));
+    assert(isEmail("o'brien@example.com"));
+    assert(isEmail("mary.o'neil@company.org"));
+    assert(isEmail("d'arcy@domain.co.uk"));
   });
 
   await t.step("returns false for invalid emails", () => {
@@ -34,6 +37,7 @@ Deno.test("isEmail", async (t) => {
   await t.step("validate method", () => {
     // Valid inputs return value
     assertEquals(isEmail.validate("test@example.com"), { value: "test@example.com" });
+    assertEquals(isEmail.validate("o'brien@example.com"), { value: "o'brien@example.com" });
 
     // Invalid inputs return issues with specific error message
     assertEquals(isEmail.validate("plainaddress"), {

--- a/packages/guardis/src/modules/strings.ts
+++ b/packages/guardis/src/modules/strings.ts
@@ -7,7 +7,7 @@ import type { TypeGuard } from "../types.ts";
 
 /** A regex statement to detect _most_ email formats. */
 const EMAIL_REGEX =
-  /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$/;
+  /^[a-zA-Z0-9._%+\'-]+@[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$/;
 
 /**
  * Type guard that checks if the provided value is a valid email string.


### PR DESCRIPTION
## Summary

- **feat**: support apostrophes in email validation — adds `'` to the `EMAIL_REGEX` local-part character class so addresses like `o'brien@example.com` are accepted; includes corresponding unit tests
- **test**: add `VerifiedShape` overload coverage for generic parameterized types — reproduces and documents the case where `createTypeGuard<T>` is called with a shape inside a generic function whose `T` cannot be proven to extend `Record<string, unknown>` at the call site
- **chore**: bump version to 0.8.1; reformat `guard.test.ts` to match `deno fmt` output

## Test plan

- [ ] `deno task test` passes (120 tests, 0 failures)
- [ ] Email addresses with apostrophes (e.g. `o'brien@example.com`) are accepted by `isEmail`
- [ ] Addresses without apostrophes continue to behave as before